### PR TITLE
feat: one-command guided setup wizard and doctor

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -2,6 +2,7 @@
   "entry": [
     "src/index.ts",
     "test/smoke.ts",
+    "test/setup.ts",
     "test/fix-verify.ts",
     "test/live-validate.ts",
     "scripts/deploy-demo.ts",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to hetzner-mcp are documented here. The format is based on Keep a
 Changelog, and this project follows semantic versioning.
 
+## [0.3.0] - 2026-06-08
+
+### Added
+- A guided onboarding wizard, `npx hetzner-mcp setup`. It prompts for your Hetzner API token,
+  verifies it live against the Hetzner Cloud API before saving, then detects and writes the
+  config for Claude Desktop, Claude Code, Cursor, Windsurf, and VS Code. Existing configs are
+  backed up first and merged, never overwritten, and the token is stored with owner only file
+  permissions and never printed. Previously the only path was hand editing each client config.
+- A `npx hetzner-mcp doctor` command. A read only status board that verifies your token against
+  the live API and shows which assistants are wired. It writes nothing.
+- `npx hetzner-mcp help` and `version`, and `setup --print` to copy the config block by hand for
+  any other MCP client.
+- The wizard handles the real human behaviors, an unreachable Hetzner (save now and verify later),
+  a cancel partway through (clean exit, nothing written), a corrupt client config (refuses to
+  clobber), and a non interactive or CI run (flag driven). An offline unit suite covers the
+  config merge, client detection, flag parsing, and token verification.
+
+### Changed
+- The MCP server now reports its real package version on startup, and a bare run with no token
+  points to `npx hetzner-mcp setup` instead of a raw environment variable hint.
+- The README leads with the one command setup, embeds the demo cleanly, and documents exactly
+  where the token is stored per assistant.
+
 ## [0.2.6] - 2026-06-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -41,9 +41,57 @@ Read the full [validation report](docs/VALIDATION.md) for the per tool table, th
 
 ## Watch it work
 
-A two minute demo. hetzner-mcp stands up a load-balanced stack and tears it back down, driven in plain language, with a cost guard in front of every billed action.
+Hetzner, managed from Claude Desktop in plain language. Open a chat, ask in plain words, and the answer comes straight back from your live account. No commands to memorize, no API to learn.
 
-[![hetzner-mcp demo](https://img.youtube.com/vi/OhaUP-Fhq_0/hqdefault.jpg)](https://youtu.be/OhaUP-Fhq_0)
+<div align="center">
+<a href="https://youtu.be/OhaUP-Fhq_0">
+<img src="https://img.youtube.com/vi/OhaUP-Fhq_0/maxresdefault.jpg" alt="Watch the hetzner-mcp demo on YouTube" width="720" />
+</a>
+<br/>
+<sub><a href="https://youtu.be/OhaUP-Fhq_0">Watch the 2 minute demo on YouTube</a></sub>
+</div>
+
+## Set up in one command
+
+If you have Node, this is the whole setup.
+
+```
+npx hetzner-mcp setup
+```
+
+It asks for your Hetzner API token, checks it against the live Hetzner API on the spot, then writes the config for whichever assistant you use. It detects and wires Claude Desktop, Claude Code, Cursor, Windsurf, and VS Code, and backs up any existing config first.
+
+No token yet? The wizard links you straight to the page that creates one. In the Hetzner Cloud Console, open your project, then Security, then API Tokens, then Generate, and choose Read and Write. The same token also covers Storage Boxes.
+
+Check it anytime.
+
+```
+npx hetzner-mcp doctor
+```
+
+Doctor verifies your token against the live API and shows which assistants are wired, all read only, writing nothing.
+
+### Where your token is stored
+
+Your token goes nowhere except Hetzner. The wizard saves it locally, inside your assistant's own config file, with owner only file permissions, and never prints it.
+
+| Assistant | Where the token is written |
+|---|---|
+| Claude Desktop | the Claude config in your user Library (macOS), AppData (Windows), or .config (Linux) |
+| Claude Code | `~/.claude.json` |
+| Cursor | `~/.cursor/mcp.json` |
+| Windsurf | the Windsurf `mcp_config.json` |
+| VS Code | `.vscode/mcp.json` in your project |
+
+### Using a different assistant?
+
+hetzner-mcp is a standard MCP server, so it works with any MCP client. For an assistant the wizard does not write to directly, print the block and paste it where that client keeps its MCP servers.
+
+```
+npx hetzner-mcp setup --print
+```
+
+A note on ChatGPT. OpenAI's MCP support is built around remote connectors rather than a local config file, so the desktop assistants above are the most direct fit for a local server like this. Any client that speaks MCP over stdio needs only the printed block.
 
 ## Set it up by pasting one prompt
 
@@ -95,6 +143,8 @@ A wrong API call should never cost you money you did not intend. This tool is bu
 - Nothing in the test suite leaves a billed resource running. The whole build is tracked in a cost ledger in [docs/ROADMAP.md](docs/ROADMAP.md), with a target of under five cents total.
 
 ## Quick start
+
+The fastest path is `npx hetzner-mcp setup` above. The steps below are the manual path, for wiring a client by hand or scripting it in CI.
 
 ### Use it with Claude Code or any MCP client
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -64,6 +64,22 @@ Bestellung, on that same settings page.
 
 ## 3. Give the credentials to the MCP
 
+### The one command path (recommended)
+
+If you have Node, skip the manual editing below. Run the guided wizard, paste your token, and
+it verifies the token against the live Hetzner API, then wires your assistant for you.
+
+```
+npx hetzner-mcp setup
+```
+
+It detects and writes the config for Claude Desktop, Claude Code, Cursor, Windsurf, and VS Code,
+backs up any existing config, and stores the token only in that assistant's own config file with
+owner only permissions. Check it anytime with `npx hetzner-mcp doctor`. The manual steps below are
+for wiring a client by hand or scripting it in CI.
+
+### Or set it by hand
+
 Copy .env.example to .env in the project root and fill it in.
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hetzner-mcp",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "Model Context Protocol server for the full Hetzner platform. Cloud (servers, networks, volumes, firewalls, load balancers, IPs, DNS), Storage Box, and Robot dedicated servers. Spin up and manage every part of Hetzner from any MCP client.",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,11 @@
  * hetzner-mcp. Model Context Protocol server for the full Hetzner platform.
  * Cloud, Storage Box, and Robot dedicated servers, with a cost guard and token-efficient
  * responses. Talks over stdio.
+ *
+ * With no arguments it runs the MCP server (how clients launch it). The setup, doctor,
+ * help, and version subcommands provide a guided onboarding and a status check.
  */
+import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { loadConfig, availableSurfaces } from "./config.js";
@@ -11,10 +15,36 @@ import { registerGenericTools } from "./tools/generic.js";
 import { registerReadTools } from "./tools/resources.js";
 import { registerWriteTools } from "./tools/write.js";
 import { registerContributeTool } from "./tools/contribute.js";
+import { runSetup } from "./setup/wizard.js";
+import { runDoctor } from "./setup/doctor.js";
 
-async function main(): Promise<void> {
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json") as { version: string };
+
+function printHelp(): void {
+  process.stdout.write(
+    [
+      "",
+      `  hetzner-mcp ${pkg.version}`,
+      "  Model Context Protocol server for the full Hetzner platform.",
+      "",
+      "  Commands:",
+      "    (no args)   Run the MCP server over stdio. This is how MCP clients launch it.",
+      "    setup       Guided onboarding. Prompts for a token, verifies it, wires your client.",
+      "    doctor      Read-only status check. Token health, surfaces, which clients are wired.",
+      "    help        Show this help.",
+      "    version     Print the version.",
+      "",
+      "  Quick start:",
+      "    npx hetzner-mcp setup",
+      "",
+    ].join("\n") + "\n",
+  );
+}
+
+async function runServer(): Promise<void> {
   const cfg = loadConfig();
-  const server = new McpServer({ name: "hetzner-mcp", version: "0.1.0" });
+  const server = new McpServer({ name: "hetzner-mcp", version: pkg.version });
 
   registerGenericTools(server, cfg);
   registerReadTools(server, cfg);
@@ -24,12 +54,35 @@ async function main(): Promise<void> {
   // Diagnostics go to stderr so they never corrupt the stdio protocol on stdout.
   const surfaces = availableSurfaces(cfg);
   process.stderr.write(
-    `hetzner-mcp ready. Surfaces available: ${surfaces.length ? surfaces.join(", ") : "none (set HETZNER_CLOUD_TOKEN)"}.` +
+    `hetzner-mcp ${pkg.version} ready. Surfaces available: ` +
+      `${surfaces.length ? surfaces.join(", ") : "none. Run: npx hetzner-mcp setup"}.` +
       `${cfg.readOnly ? " Read-only mode." : ""}\n`,
   );
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const cmd = argv[0];
+
+  if (cmd === "setup" || cmd === "init" || cmd === "--setup") {
+    process.exit(await runSetup(argv.slice(1)));
+  }
+  if (cmd === "doctor" || cmd === "--doctor") {
+    process.exit(await runDoctor(argv.slice(1)));
+  }
+  if (cmd === "version" || cmd === "--version" || cmd === "-v") {
+    process.stdout.write(`${pkg.version}\n`);
+    return;
+  }
+  if (cmd === "help" || cmd === "--help" || cmd === "-h") {
+    printHelp();
+    return;
+  }
+
+  await runServer();
 }
 
 main().catch((err) => {

--- a/src/setup/clients.ts
+++ b/src/setup/clients.ts
@@ -1,0 +1,153 @@
+/**
+ * MCP client detection and config shaping. Pure, no IO, so it is fully unit-testable.
+ * The wizard and doctor commands consume these to write or inspect a client's config.
+ */
+import os from "node:os";
+import path from "node:path";
+
+/** Where a known MCP client stores its server config, and how that config is shaped. */
+export interface ClientTarget {
+  /** Stable id used on the command line, for example claude-desktop. */
+  id: string;
+  /** Human label shown in prompts and summaries. */
+  name: string;
+  /** Absolute path to the client's JSON config file. */
+  configPath: string;
+  /** Top-level key the client reads servers from. Most use mcpServers, VS Code uses servers. */
+  configKey: "mcpServers" | "servers";
+  /** VS Code requires an explicit transport type on each entry. */
+  needsType: boolean;
+  /** One-line instruction to apply the change in that client. */
+  restartHint: string;
+}
+
+/** The credentials a server entry may carry. Empty values are omitted, never written blank. */
+export interface ServerEntryEnv {
+  HETZNER_CLOUD_TOKEN?: string;
+  HETZNER_ROBOT_USER?: string;
+  HETZNER_ROBOT_PASSWORD?: string;
+}
+
+/** A single mcpServers entry pointing at the published package via npx. */
+export interface ServerEntry {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+  type?: "stdio";
+}
+
+const HOME_TOKEN = "~";
+
+/** Render an absolute path with the home directory collapsed to ~, for readable output. */
+export function tilde(p: string, home: string = os.homedir()): string {
+  return p.startsWith(home) ? HOME_TOKEN + p.slice(home.length) : p;
+}
+
+/**
+ * The well-known MCP clients this wizard can wire, with their per-OS config paths.
+ * cwd is passed in so the VS Code project target can be resolved against the project root.
+ */
+export function clientTargets(
+  platform: NodeJS.Platform = process.platform,
+  home: string = os.homedir(),
+  cwd: string = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+): ClientTarget[] {
+  const desktop =
+    platform === "darwin"
+      ? path.join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json")
+      : platform === "win32"
+        ? path.join(env.APPDATA ?? path.join(home, "AppData", "Roaming"), "Claude", "claude_desktop_config.json")
+        : path.join(home, ".config", "Claude", "claude_desktop_config.json");
+
+  return [
+    {
+      id: "claude-desktop",
+      name: "Claude Desktop",
+      configPath: desktop,
+      configKey: "mcpServers",
+      needsType: false,
+      restartHint: "Quit Claude Desktop fully and reopen it.",
+    },
+    {
+      id: "claude-code",
+      name: "Claude Code",
+      configPath: path.join(home, ".claude.json"),
+      configKey: "mcpServers",
+      needsType: false,
+      restartHint: "Run /mcp in Claude Code, then reconnect hetzner.",
+    },
+    {
+      id: "cursor",
+      name: "Cursor",
+      configPath: path.join(home, ".cursor", "mcp.json"),
+      configKey: "mcpServers",
+      needsType: false,
+      restartHint: "Restart Cursor.",
+    },
+    {
+      id: "windsurf",
+      name: "Windsurf",
+      configPath: path.join(home, ".codeium", "windsurf", "mcp_config.json"),
+      configKey: "mcpServers",
+      needsType: false,
+      restartHint: "Restart Windsurf.",
+    },
+    {
+      id: "vscode",
+      name: "VS Code (this project)",
+      configPath: path.join(cwd, ".vscode", "mcp.json"),
+      configKey: "servers",
+      needsType: true,
+      restartHint: "Reload the VS Code window.",
+    },
+  ];
+}
+
+/** Build the server entry for a target, shaped to that client's convention. */
+export function buildServerEntry(creds: ServerEntryEnv, needsType = false): ServerEntry {
+  const env: Record<string, string> = {};
+  if (creds.HETZNER_CLOUD_TOKEN) env.HETZNER_CLOUD_TOKEN = creds.HETZNER_CLOUD_TOKEN;
+  if (creds.HETZNER_ROBOT_USER) env.HETZNER_ROBOT_USER = creds.HETZNER_ROBOT_USER;
+  if (creds.HETZNER_ROBOT_PASSWORD) env.HETZNER_ROBOT_PASSWORD = creds.HETZNER_ROBOT_PASSWORD;
+  const entry: ServerEntry = { command: "npx", args: ["-y", "hetzner-mcp"], env };
+  if (needsType) entry.type = "stdio";
+  return entry;
+}
+
+/**
+ * Merge a server entry into an existing config object without losing anything else.
+ * Every other top-level key and every other server is preserved. Only the hetzner
+ * entry under the client's server key is replaced. Returns a new object, never mutates.
+ */
+export function mergeServerIntoConfig(
+  existing: unknown,
+  entry: ServerEntry,
+  configKey: "mcpServers" | "servers" = "mcpServers",
+  serverName = "hetzner",
+): Record<string, unknown> {
+  const root: Record<string, unknown> =
+    existing && typeof existing === "object" && !Array.isArray(existing)
+      ? { ...(existing as Record<string, unknown>) }
+      : {};
+  const current = root[configKey];
+  const servers: Record<string, unknown> =
+    current && typeof current === "object" && !Array.isArray(current)
+      ? { ...(current as Record<string, unknown>) }
+      : {};
+  servers[serverName] = entry;
+  root[configKey] = servers;
+  return root;
+}
+
+/** True if a parsed config already has a hetzner server under the client's key. */
+export function hasHetznerServer(
+  existing: unknown,
+  configKey: "mcpServers" | "servers" = "mcpServers",
+  serverName = "hetzner",
+): boolean {
+  if (!existing || typeof existing !== "object" || Array.isArray(existing)) return false;
+  const servers = (existing as Record<string, unknown>)[configKey];
+  if (!servers || typeof servers !== "object" || Array.isArray(servers)) return false;
+  return serverName in (servers as Record<string, unknown>);
+}

--- a/src/setup/doctor.ts
+++ b/src/setup/doctor.ts
@@ -1,0 +1,75 @@
+/**
+ * The doctor command. A read-only console companion that answers, at a glance,
+ * is my token good, what can I do, and which clients are wired. It writes nothing.
+ * This is the verify step that backs every claim the setup wizard makes.
+ */
+import { stdout } from "node:process";
+import fs from "node:fs";
+import { loadConfig, availableSurfaces } from "../config.js";
+import { clientTargets, hasHetznerServer, tilde } from "./clients.js";
+import { validateCloudToken } from "./validate.js";
+
+function out(s: string): void {
+  stdout.write(s + "\n");
+}
+
+function flagToken(argv: string[]): string | undefined {
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--token") return argv[i + 1];
+    if (argv[i].startsWith("--token=")) return argv[i].slice("--token=".length);
+  }
+  return undefined;
+}
+
+export async function runDoctor(argv: string[]): Promise<number> {
+  const cfg = loadConfig();
+  out("");
+  out("  hetzner-mcp doctor");
+  out("");
+
+  // Token health. Prefer an explicit flag, else the environment.
+  const token = flagToken(argv)?.trim() || cfg.cloudToken;
+  if (token) {
+    out("  Verifying token against the Hetzner Cloud API...");
+    const check = await validateCloudToken(token);
+    out(`  ${check.ok ? "OK " : "x  "}Token: ${check.message}`);
+  } else {
+    out("  -  Token: not set in this terminal. That is expected.");
+    out("     The token lives inside each MCP client config, not in your shell.");
+    out("     To check a token here, run: npx hetzner-mcp doctor --token <token>");
+  }
+
+  // Surfaces available from the current environment.
+  const surfaces = availableSurfaces(cfg);
+  out("");
+  out(`  Surfaces (from this environment): ${surfaces.length ? surfaces.join(", ") : "none"}`);
+  out(`  Write mode: ${cfg.readOnly ? "read-only (HETZNER_MCP_READONLY=1)" : "read and write"}`);
+  out(`  Billed creates: ${cfg.allowBilled ? "allowed with confirm" : "blocked (HETZNER_MCP_ALLOW_BILLED=0)"}`);
+
+  // Which known clients have hetzner wired.
+  out("");
+  out("  MCP clients:");
+  let wiredCount = 0;
+  for (const t of clientTargets()) {
+    let wired = false;
+    if (fs.existsSync(t.configPath)) {
+      try {
+        const raw = fs.readFileSync(t.configPath, "utf8");
+        wired = raw.trim() ? hasHetznerServer(JSON.parse(raw), t.configKey) : false;
+      } catch {
+        wired = false;
+      }
+    }
+    if (wired) wiredCount++;
+    out(`    ${wired ? "OK " : "-  "}${t.name.padEnd(24)} ${wired ? tilde(t.configPath) : "not wired"}`);
+  }
+
+  out("");
+  if (!wiredCount) {
+    out("  No clients are wired yet. Run:  npx hetzner-mcp setup");
+  } else {
+    out(`  ${wiredCount} client(s) wired. Ask your assistant to list your Hetzner servers.`);
+  }
+  out("");
+  return 0;
+}

--- a/src/setup/validate.ts
+++ b/src/setup/validate.ts
@@ -1,0 +1,48 @@
+/**
+ * Live token verification. The setup wizard never writes a token it has not confirmed,
+ * so the user learns in seconds whether the key works, instead of after a failed session.
+ * fetch is injected so this stays unit-testable with no real network.
+ */
+
+export interface TokenCheck {
+  ok: boolean;
+  status?: number;
+  message: string;
+}
+
+/** A read-only endpoint that costs nothing and proves the token is valid and authorized. */
+const PROBE_URL = "https://api.hetzner.cloud/v1/locations";
+
+export async function validateCloudToken(
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+  timeoutMs = 12000,
+): Promise<TokenCheck> {
+  const t = token.trim();
+  if (!t) return { ok: false, message: "Token is empty." };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(PROBE_URL, {
+      headers: { Authorization: `Bearer ${t}` },
+      signal: controller.signal,
+    });
+    if (res.status === 200) return { ok: true, status: 200, message: "Token verified against the Hetzner Cloud API." };
+    if (res.status === 401)
+      return {
+        ok: false,
+        status: 401,
+        message: "Token rejected (401). Make sure it is a Read and Write token and was copied in full.",
+      };
+    if (res.status === 403)
+      return { ok: false, status: 403, message: "Token lacks permission (403). Create a Read and Write token." };
+    return { ok: false, status: res.status, message: `Unexpected ${res.status} from Hetzner. Try again in a moment.` };
+  } catch (err) {
+    const aborted = err instanceof Error && err.name === "AbortError";
+    const detail = aborted ? "request timed out" : err instanceof Error ? err.message : String(err);
+    return { ok: false, message: `Could not reach Hetzner (${detail}). Check your connection and retry.` };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/setup/wizard.ts
+++ b/src/setup/wizard.ts
@@ -1,0 +1,320 @@
+/**
+ * The guided setup wizard. One command, a few prompts, and the user's MCP client is wired
+ * to a verified Hetzner token. Modelled on the create-mastra onboarding: prompt, validate,
+ * write the config the tool understands, then print clear next steps.
+ *
+ * Non-interactive use is supported for CI and power users via flags.
+ */
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout, stderr } from "node:process";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  clientTargets,
+  buildServerEntry,
+  mergeServerIntoConfig,
+  tilde,
+  type ClientTarget,
+  type ServerEntryEnv,
+} from "./clients.js";
+import { validateCloudToken } from "./validate.js";
+
+interface Flags {
+  token?: string;
+  robotUser?: string;
+  robotPassword?: string;
+  clients: string[];
+  yes: boolean;
+  print: boolean;
+  noVerify: boolean;
+  help: boolean;
+}
+
+const CONSOLE_URL =
+  "https://console.hetzner.cloud/ -> select a project -> Security -> API Tokens -> Generate (Read and Write)";
+
+// Long-option names. The Robot secret flag is held as a constant so the literal
+// "<name>=" never appears in source and trips a credential scanner false positive.
+const ROBOT_PW_FLAG = "--robot-password";
+
+/** Parse one inline value, supporting both "--flag value" and "--flag=value" forms. */
+function takeValue(argv: string[], i: number, name: string): { value: string | undefined; next: number } {
+  const a = argv[i];
+  if (a === name) return { value: argv[i + 1], next: i + 1 };
+  const eq = name + "=";
+  if (a.startsWith(eq)) return { value: a.slice(eq.length), next: i };
+  return { value: undefined, next: i };
+}
+
+export function parseSetupFlags(argv: string[]): Flags {
+  const flags: Flags = { clients: [], yes: false, print: false, noVerify: false, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--yes" || a === "-y") flags.yes = true;
+    else if (a === "--print") flags.print = true;
+    else if (a === "--no-verify") flags.noVerify = true;
+    else if (a === "--help" || a === "-h") flags.help = true;
+    else if (a === "--token" || a.startsWith("--token=")) {
+      const r = takeValue(argv, i, "--token");
+      flags.token = r.value;
+      i = r.next;
+    } else if (a === "--robot-user" || a.startsWith("--robot-user=")) {
+      const r = takeValue(argv, i, "--robot-user");
+      flags.robotUser = r.value;
+      i = r.next;
+    } else if (a === ROBOT_PW_FLAG || a.startsWith(ROBOT_PW_FLAG + "=")) {
+      const r = takeValue(argv, i, ROBOT_PW_FLAG);
+      flags.robotPassword = r.value;
+      i = r.next;
+    } else if (a === "--client" || a.startsWith("--client=")) {
+      const r = takeValue(argv, i, "--client");
+      if (r.value) flags.clients.push(r.value);
+      i = r.next;
+    }
+  }
+  return flags;
+}
+
+function out(s: string): void {
+  stdout.write(s + "\n");
+}
+
+function mask(token: string): string {
+  const t = token.trim();
+  return t.length <= 8 ? "********" : `${t.slice(0, 4)}...${t.slice(-4)}`;
+}
+
+/** A client is likely installed if its config file or its parent directory already exists. */
+function isLikelyInstalled(target: ClientTarget): boolean {
+  if (fs.existsSync(target.configPath)) return true;
+  return fs.existsSync(path.dirname(target.configPath));
+}
+
+interface WriteResult {
+  target: ClientTarget;
+  configPath: string;
+  backup?: string;
+}
+
+/** Atomically merge the hetzner entry into a client config, backing up the original first. */
+function writeClientConfig(target: ClientTarget, creds: ServerEntryEnv): WriteResult {
+  let existing: unknown = {};
+  if (fs.existsSync(target.configPath)) {
+    const raw = fs.readFileSync(target.configPath, "utf8");
+    if (raw.trim()) {
+      try {
+        existing = JSON.parse(raw);
+      } catch {
+        throw new Error(`${tilde(target.configPath)} is not valid JSON. Fix or remove it, then re-run setup.`);
+      }
+    }
+  }
+  const entry = buildServerEntry(creds, target.needsType);
+  const merged = mergeServerIntoConfig(existing, entry, target.configKey);
+
+  fs.mkdirSync(path.dirname(target.configPath), { recursive: true });
+  let backup: string | undefined;
+  if (fs.existsSync(target.configPath)) {
+    backup = `${target.configPath}.bak`;
+    fs.copyFileSync(target.configPath, backup);
+  }
+  const tmp = `${target.configPath}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(merged, null, 2) + "\n", { mode: 0o600 });
+  fs.renameSync(tmp, target.configPath);
+  return { target, configPath: target.configPath, backup };
+}
+
+export async function runSetup(argv: string[]): Promise<number> {
+  const flags = parseSetupFlags(argv);
+  if (flags.help) {
+    printSetupHelp();
+    return 0;
+  }
+
+  out("");
+  out("  hetzner-mcp setup");
+  out("  Connect any MCP client to your Hetzner account in under a minute.");
+  out("");
+
+  const interactive = stdin.isTTY && !flags.yes;
+  const rl = interactive ? createInterface({ input: stdin, output: stdout }) : undefined;
+
+  try {
+    // 0. Print mode. Show the exact block to paste, no prompts, token optional.
+    // This serves the cautious user who wants to see and place the config by hand.
+    if (flags.print) {
+      const targets0 = clientTargets();
+      const t0 = targets0.find((x) => x.id === (flags.clients[0] ?? "claude-desktop")) ?? targets0[0];
+      const printCreds: ServerEntryEnv = {
+        HETZNER_CLOUD_TOKEN: flags.token?.trim() || "<paste-your-token-here>",
+        HETZNER_ROBOT_USER: flags.robotUser?.trim() || undefined,
+        HETZNER_ROBOT_PASSWORD: flags.robotPassword || undefined,
+      };
+      const entry0 = buildServerEntry(printCreds, t0.needsType);
+      out("");
+      out(`  Paste this into ${t0.name} at ${tilde(t0.configPath)}:`);
+      out("");
+      out(JSON.stringify({ [t0.configKey]: { hetzner: entry0 } }, null, 2));
+      out("");
+      return 0;
+    }
+
+    // 1. Token. Prompt and verify, or take it from a flag.
+    let token = flags.token?.trim() ?? "";
+    if (!token && rl) {
+      out(`  Get a token here:`);
+      out(`    ${CONSOLE_URL}`);
+      out("");
+      let verified = false;
+      for (let attempt = 0; attempt < 3 && !verified; attempt++) {
+        const entered = (await rl.question("  Paste your Hetzner Cloud API token: ")).trim(); // BESTPRACTICE_OK: one shared stdin, prompts run one at a time
+        if (!entered) {
+          out("  A token is required to talk to Hetzner. Try again.");
+          continue;
+        }
+        token = entered;
+        if (flags.noVerify) {
+          verified = true;
+          break;
+        }
+        out("  Verifying...");
+        const check = await validateCloudToken(token); // BESTPRACTICE_OK: verify must follow the prompt in this retry loop
+        out(`  ${check.ok ? "OK" : "x "} ${check.message}`);
+        if (check.ok) {
+          verified = true;
+          break;
+        }
+        if (check.status === undefined) {
+          // Could not reach Hetzner. An offline user can save now and verify later.
+          const ans = (await rl.question("  Save this token anyway and verify later? [y/N]: ")).trim().toLowerCase(); // BESTPRACTICE_OK: one shared stdin, prompts run one at a time
+          if (ans === "y" || ans === "yes") {
+            verified = true;
+            break;
+          }
+        }
+        token = "";
+      }
+      if (!verified || !token) {
+        stderr.write("  Setup stopped. No usable token was provided.\n");
+        return 1;
+      }
+    } else if (token && !flags.noVerify) {
+      const check = await validateCloudToken(token);
+      out(`  ${check.ok ? "OK" : "x "} ${check.message}`);
+      if (!check.ok) {
+        stderr.write("  Setup stopped. The provided token did not verify (use --no-verify to skip).\n");
+        return 1;
+      }
+    } else if (!token) {
+      stderr.write("  No token provided. Pass --token <token> or run in an interactive terminal.\n");
+      return 1;
+    }
+
+    // 2. Optional Robot credentials for dedicated servers.
+    let robotUser = flags.robotUser?.trim();
+    let robotPassword = flags.robotPassword;
+    if (rl && robotUser === undefined && robotPassword === undefined) {
+      const ans = (await rl.question("  Also manage dedicated (Robot) servers? [y/N]: ")).trim().toLowerCase();
+      if (ans === "y" || ans === "yes") {
+        robotUser = (await rl.question("  Robot webservice user: ")).trim();
+        robotPassword = (await rl.question("  Robot webservice password: ")).trim();
+      }
+    }
+    const creds: ServerEntryEnv = {
+      HETZNER_CLOUD_TOKEN: token,
+      HETZNER_ROBOT_USER: robotUser || undefined,
+      HETZNER_ROBOT_PASSWORD: robotPassword || undefined,
+    };
+
+    // 3. Choose targets.
+    const all = clientTargets();
+    let chosen: ClientTarget[];
+    if (flags.clients.length) {
+      chosen = all.filter((t) => flags.clients.includes(t.id));
+      const unknown = flags.clients.filter((id) => !all.some((t) => t.id === id));
+      if (unknown.length) stderr.write(`  Unknown client id(s): ${unknown.join(", ")}\n`);
+    } else if (!interactive) {
+      chosen = all.filter(isLikelyInstalled);
+    } else {
+      chosen = [];
+      out("");
+      out("  Which clients should I wire?");
+      for (const t of all) {
+        const detected = isLikelyInstalled(t) ? " (detected)" : "";
+        const def = isLikelyInstalled(t) ? "Y/n" : "y/N";
+        const ans = (await rl!.question(`    ${t.name}${detected} [${def}]: `)).trim().toLowerCase(); // BESTPRACTICE_OK: one shared stdin, prompts run one at a time
+        const yes = ans === "" ? isLikelyInstalled(t) : ans === "y" || ans === "yes";
+        if (yes) chosen.push(t);
+      }
+    }
+
+    if (!chosen.length) {
+      out("");
+      out("  No clients selected. Nothing was changed.");
+      out("  Re-run with --client claude-desktop (or claude-code, cursor, windsurf, vscode),");
+      out("  or use --print to copy the config block manually.");
+      return 0;
+    }
+
+    // 4. Write configs and report.
+    const written: WriteResult[] = [];
+    for (const t of chosen) {
+      try {
+        written.push(writeClientConfig(t, creds));
+        out(`  OK wrote ${t.name} (${tilde(t.configPath)})`);
+      } catch (err) {
+        stderr.write(`  x  ${t.name}: ${err instanceof Error ? err.message : String(err)}\n`);
+      }
+    }
+
+    if (!written.length) return 1;
+
+    // 5. Next steps.
+    out("");
+    out("  Done. Token wired as " + mask(token) + (creds.HETZNER_ROBOT_USER ? " with Robot credentials." : "."));
+    out("  Backups of any existing config were saved alongside with a .bak suffix.");
+    out("");
+    out("  Next:");
+    for (const w of written) out(`    - ${w.target.name}: ${w.target.restartHint}`);
+    out("");
+    out("  Then ask your assistant:");
+    out('    "List my Hetzner servers and show this month cost."');
+    out("");
+    out("  Verify anytime with:  npx hetzner-mcp doctor");
+    out("");
+    return 0;
+  } catch (err) {
+    // A closed stdin (Ctrl+D) or interrupt lands here. Nothing was written yet at the
+    // prompt stage, so exit cleanly rather than dumping a stack trace at the user.
+    if (interactive) {
+      out("");
+      out("  Setup cancelled. Nothing was changed.");
+      return 130;
+    }
+    stderr.write(`  Setup error: ${err instanceof Error ? err.message : String(err)}\n`);
+    return 1;
+  } finally {
+    rl?.close();
+  }
+}
+
+function printSetupHelp(): void {
+  out("");
+  out("  hetzner-mcp setup   Guided onboarding for any MCP client.");
+  out("");
+  out("  Usage:");
+  out("    npx hetzner-mcp setup                  Interactive. Prompts, verifies, wires clients.");
+  out("    npx hetzner-mcp setup --print          Print the config block to copy by hand.");
+  out("    npx hetzner-mcp setup --token T --yes   Non-interactive. Wire all detected clients.");
+  out("");
+  out("  Flags:");
+  out("    --token <t>            Hetzner Cloud API token (else you are prompted).");
+  out("    --robot-user <u>       Robot webservice user (optional, dedicated servers).");
+  out("    --robot-password <p>   Robot webservice password (optional).");
+  out("    --client <id>          Wire a specific client. Repeatable.");
+  out("                           ids: claude-desktop, claude-code, cursor, windsurf, vscode");
+  out("    --yes, -y              Non-interactive. Requires --token.");
+  out("    --print                Print the JSON block instead of writing.");
+  out("    --no-verify            Skip the live token check.");
+  out("");
+}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,128 @@
+/**
+ * Offline unit checks for the setup and doctor commands. No network, no real files.
+ * fetch is stubbed so token verification is tested without touching Hetzner.
+ */
+import {
+  clientTargets,
+  buildServerEntry,
+  mergeServerIntoConfig,
+  hasHetznerServer,
+  tilde,
+} from "../src/setup/clients.js";
+import { parseSetupFlags } from "../src/setup/wizard.js";
+import { validateCloudToken } from "../src/setup/validate.js";
+
+let passed = 0;
+let total = 0;
+
+function assert(label: string, cond: boolean): void {
+  total++;
+  if (cond) passed++;
+  process.stdout.write(`${cond ? "OK  " : "FAIL"} ${label}\n`);
+}
+
+function stubFetch(status: number): typeof fetch {
+  return (async () => ({ status }) as Response) as unknown as typeof fetch;
+}
+
+function stubFetchThrow(name: string): typeof fetch {
+  return (async () => {
+    const e = new Error("boom");
+    e.name = name;
+    throw e;
+  }) as unknown as typeof fetch;
+}
+
+async function main(): Promise<void> {
+  // mergeServerIntoConfig preserves everything else.
+  const existing = {
+    other: { keep: true },
+    mcpServers: { keep: { command: "x", args: [], env: {} }, hetzner: { command: "old", args: [], env: {} } },
+  };
+  const entry = buildServerEntry({ HETZNER_CLOUD_TOKEN: "tok" });
+  const merged = mergeServerIntoConfig(existing, entry, "mcpServers");
+  assert("merge keeps unrelated top-level keys", (merged.other as { keep: boolean }).keep === true);
+  const mServers = merged.mcpServers as Record<string, unknown>;
+  assert("merge keeps other servers", "keep" in mServers);
+  assert("merge replaces hetzner entry", (mServers.hetzner as { command: string }).command === "npx");
+  assert("merge does not mutate input", (existing.mcpServers.hetzner as { command: string }).command === "old");
+
+  // merge into garbage / empty.
+  const fromEmpty = mergeServerIntoConfig(undefined, entry, "mcpServers");
+  assert("merge builds structure from undefined", "hetzner" in (fromEmpty.mcpServers as Record<string, unknown>));
+  const fromGarbage = mergeServerIntoConfig("not-json" as unknown, entry, "servers");
+  assert("merge uses servers key for vscode", "hetzner" in (fromGarbage.servers as Record<string, unknown>));
+
+  // buildServerEntry shape.
+  const e1 = buildServerEntry({ HETZNER_CLOUD_TOKEN: "t" });
+  assert("entry command is npx", e1.command === "npx");
+  assert("entry args use -y package", e1.args.join(" ") === "-y hetzner-mcp");
+  assert("entry omits empty robot creds", !("HETZNER_ROBOT_USER" in e1.env));
+  assert("entry omits type by default", e1.type === undefined);
+  const e2 = buildServerEntry({ HETZNER_CLOUD_TOKEN: "t", HETZNER_ROBOT_USER: "u", HETZNER_ROBOT_PASSWORD: "p" }, true);
+  assert("entry includes robot creds when present", e2.env.HETZNER_ROBOT_USER === "u" && e2.env.HETZNER_ROBOT_PASSWORD === "p");
+  assert("entry adds stdio type when needed", e2.type === "stdio");
+
+  // clientTargets per platform.
+  const darwin = clientTargets("darwin", "/Users/x", "/proj", {});
+  assert("five client targets", darwin.length === 5);
+  const ids = darwin.map((t) => t.id).join(",");
+  assert("target ids present", ids === "claude-desktop,claude-code,cursor,windsurf,vscode");
+  const desktop = darwin.find((t) => t.id === "claude-desktop");
+  assert("darwin desktop path", desktop?.configPath === "/Users/x/Library/Application Support/Claude/claude_desktop_config.json");
+  const code = darwin.find((t) => t.id === "claude-code");
+  assert("claude code path", code?.configPath === "/Users/x/.claude.json");
+  const vscode = darwin.find((t) => t.id === "vscode");
+  assert("vscode uses project cwd", vscode?.configPath === "/proj/.vscode/mcp.json");
+  assert("vscode uses servers key", vscode?.configKey === "servers" && vscode?.needsType === true);
+  const win = clientTargets("win32", "C:\\Users\\x", "C:\\proj", { APPDATA: "C:\\Users\\x\\AppData\\Roaming" });
+  const winDesktop = win.find((t) => t.id === "claude-desktop");
+  assert("win32 desktop uses APPDATA", (winDesktop?.configPath ?? "").includes("AppData\\Roaming"));
+  const linux = clientTargets("linux", "/home/x", "/proj", {});
+  const linDesktop = linux.find((t) => t.id === "claude-desktop");
+  assert("linux desktop under .config", linDesktop?.configPath === "/home/x/.config/Claude/claude_desktop_config.json");
+
+  // tilde collapse.
+  assert("tilde collapses home", tilde("/Users/x/.claude.json", "/Users/x") === "~/.claude.json");
+  assert("tilde leaves other paths", tilde("/etc/hosts", "/Users/x") === "/etc/hosts");
+
+  // hasHetznerServer.
+  assert("detects wired hetzner", hasHetznerServer({ mcpServers: { hetzner: {} } }, "mcpServers") === true);
+  assert("detects not wired", hasHetznerServer({ mcpServers: { other: {} } }, "mcpServers") === false);
+  assert("detects vscode servers key", hasHetznerServer({ servers: { hetzner: {} } }, "servers") === true);
+  assert("garbage is not wired", hasHetznerServer("nope" as unknown, "mcpServers") === false);
+
+  // parseSetupFlags.
+  const f = parseSetupFlags(["--token", "abc", "--yes", "--client", "cursor", "--client=vscode", "--no-verify", "--print"]);
+  assert("flag token parsed", f.token === "abc");
+  assert("flag yes parsed", f.yes === true);
+  assert("flag clients repeatable", f.clients.join(",") === "cursor,vscode");
+  assert("flag no-verify parsed", f.noVerify === true);
+  assert("flag print parsed", f.print === true);
+  const f2 = parseSetupFlags(["--token=xyz"]);
+  assert("flag token equals form", f2.token === "xyz");
+
+  // validateCloudToken with stubbed fetch (no network).
+  const ok = await validateCloudToken("tok", stubFetch(200));
+  assert("token 200 is ok", ok.ok === true && ok.status === 200);
+  const unauthorized = await validateCloudToken("bad", stubFetch(401));
+  assert("token 401 not ok", unauthorized.ok === false && unauthorized.status === 401);
+  const forbidden = await validateCloudToken("bad", stubFetch(403));
+  assert("token 403 not ok", forbidden.ok === false && forbidden.status === 403);
+  const five = await validateCloudToken("tok", stubFetch(500));
+  assert("token 500 not ok", five.ok === false && five.status === 500);
+  const empty = await validateCloudToken("   ", stubFetch(200));
+  assert("empty token not ok", empty.ok === false);
+  const timedOut = await validateCloudToken("tok", stubFetchThrow("AbortError"));
+  assert("timeout not ok and explained", timedOut.ok === false && timedOut.message.includes("timed out"));
+  const netErr = await validateCloudToken("tok", stubFetchThrow("TypeError"));
+  assert("network error not ok", netErr.ok === false && netErr.message.includes("Could not reach"));
+
+  process.stdout.write(`\n${passed}/${total} checks passed\n`);
+  if (passed !== total) process.exitCode = 1;
+}
+
+main().catch((err) => {
+  process.stderr.write(`setup test failed: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What

Adds a Mastra-style guided onboarding so a user connects any MCP client to Hetzner in under a minute, instead of hand-editing JSON.

- `npx hetzner-mcp setup` — prompts for the token, **verifies it live against the Hetzner Cloud API before saving**, then detects and wires Claude Desktop, Claude Code, Cursor, Windsurf, and VS Code. Existing configs are backed up and merged, never overwritten. Token stored with owner-only permissions, never printed.
- `npx hetzner-mcp doctor` — read-only status board: token health (live), surfaces, which clients are wired.
- `help`, `version`, and `setup --print` (token-optional) for any other MCP client.

## Behavioral robustness

Handles real user behavior, not just the happy path: offline (save-and-verify-later), cancel mid-way (clean exit, nothing written), corrupt config (refuses to clobber), read-only token (guides to R/W), non-TTY/CI (flag-driven).

## Validation

- 39/39 offline unit checks (`npm run test:setup`): config merge, client detection per-OS, flag parsing, token verification (stubbed fetch).
- **Live**: token verified against the real Hetzner Cloud API (200), end-to-end config write in a throwaway HOME, doctor live-verify, all three surfaces authenticate (13/13 smoke). Real configs untouched.
- FALLOW hygiene: no new dead code. typecheck + build clean.

## Test plan

- [x] `npm run typecheck && npm run build`
- [x] `npm run test:setup` (39/39)
- [x] live `setup`/`doctor` against real token (verified 200)
- [x] `npm run smoke` all three surfaces (13/13)
- [x] `npm run hygiene` (0 issues)