### PR TITLE
🛡️ Sentinel: Fix URL Path Traversal and SSRF Bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-14 - URL Path Traversal and SSRF Bypass via Percent Encoding and Backslash
+**Vulnerability:** URL Path Traversal and SSRF via percent-encoded dots (e.g. `%2e%2e`), percent-encoded backslashes (e.g. `%5c`), or literal backslashes (`\`) leading to relative or absolute path traversal when normalized by Node's URL parser.
+**Learning:** In Node's WHATWG URL implementation, backslashes (`\`) are normalized to forward slashes (`/`) and percent-encoded dots (such as `%2e%2e`) are resolved to dot-dot segments during parsing. To safely prevent path traversal and SSRF, path validation must decode the path via `decodeURIComponent` and explicitly check for both `..` and `\`.
+**Prevention:** Always decode input paths first with `decodeURIComponent` before performing any blocklist checks or path-containment checks for `..` or forbidden characters (such as backslashes `\`), ensuring that any URL parser normalization cannot bypass safety guards.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hetzner-mcp",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hetzner-mcp",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/security.ts
+++ b/src/security.ts
@@ -19,9 +19,21 @@ export function normalizePath(path: string): string {
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw) || raw.startsWith("//")) {
     throw new Error("path must be a relative API path like /servers, not a full URL");
   }
-  if (raw.includes("..")) {
+  // Decode path to catch percent-encoded bypasses like %2e%2e or %5c
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    throw new Error("path contains invalid percent encoding");
+  }
+
+  if (decoded.includes("..")) {
     throw new Error("path must not contain '..'");
   }
+  if (decoded.includes("\\")) {
+    throw new Error("path must not contain '\\'");
+  }
+
   for (let i = 0; i < raw.length; i++) {
     const c = raw.charCodeAt(i);
     if (c < 0x20 || c === 0x7f) {

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -53,6 +53,33 @@ async function main(): Promise<void> {
   }
   assert("security: reject path traversal", travOk);
 
+  let travPercentDotOk = true;
+  try {
+    normalizePath("/servers/%2e%2e/%2e%2e/admin");
+    travPercentDotOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject percent-encoded path traversal", travPercentDotOk);
+
+  let backslashOk = true;
+  try {
+    normalizePath("/servers/..\\..\\admin");
+    backslashOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject literal backslash traversal", backslashOk);
+
+  let percentBackslashOk = true;
+  try {
+    normalizePath("/servers/..%5c..%5cadmin");
+    percentBackslashOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject percent-encoded backslash traversal", percentBackslashOk);
+
   // Cost guard unit checks (no network). Billed creates and billed actions must be flagged,
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
   const costChecks = [
@@ -73,8 +100,14 @@ async function main(): Promise<void> {
     await check("robot /server", "robot", "/server"),
   ];
   const passed =
-    results.filter(Boolean).length + (secOk ? 1 : 0) + (travOk ? 1 : 0) + costChecks.filter(Boolean).length;
-  const total = results.length + 2 + costChecks.length;
+    results.filter(Boolean).length +
+    (secOk ? 1 : 0) +
+    (travOk ? 1 : 0) +
+    (travPercentDotOk ? 1 : 0) +
+    (backslashOk ? 1 : 0) +
+    (percentBackslashOk ? 1 : 0) +
+    costChecks.filter(Boolean).length;
+  const total = results.length + 5 + costChecks.length;
   process.stdout.write(`\n${passed}/${total} checks passed\n`);
   if (passed !== total) process.exitCode = 1;
 }


### PR DESCRIPTION
Implements a robust security mitigation against URL path traversal and SSRF attacks in the MCP request tool's path argument. In Node's WHATWG URL implementation, backslashes and percent-encoded characters like `%2e%2e` or `%5c` are normalized/resolved to dot-dot segments during parsing, which could allow attackers to bypass simple substring checks. This patch decodes the path first and checks for both `..` and `\` to block such bypasses. Includes full test coverage and the Sentinel critical security journal entry.

---
*PR created automatically by Jules for task [393101314191492374](https://jules.google.com/task/393101314191492374) started by @mjmirza*