### PR TITLE
🛡️ Sentinel: Harden path normalization against percent-encoded traversal and backslashes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal: Critical Security Learnings Only
+
+## 2026-06-07 - SSRF-safe Path Traversal Validation
+**Vulnerability:** Path Traversal (SSRF) via crafted url segments or control characters.
+**Learning:** In Node's WHATWG URL implementation, backslashes '\' are normalized to '/' and percent-encoded dots (like '%2e%2e') are resolved to dot-dot segments during parsing. To safely prevent path traversal and SSRF, path validation must decode the path via 'decodeURIComponent' and explicitly check for both '..' and '\'.
+**Prevention:** Always decode user-supplied paths and query strings before checking for directory traversal sequences. Rejects paths with full protocol markers, relative-protocol markers, backslashes, and dot-dot (`..`) patterns.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hetzner-mcp",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hetzner-mcp",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/security.ts
+++ b/src/security.ts
@@ -19,11 +19,19 @@ export function normalizePath(path: string): string {
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw) || raw.startsWith("//")) {
     throw new Error("path must be a relative API path like /servers, not a full URL");
   }
-  if (raw.includes("..")) {
-    throw new Error("path must not contain '..'");
+  // Decode the path to defend against percent-encoded path traversal/SSRF (e.g. %2e%2e, %5c)
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    throw new Error("path contains invalid percent-encoding");
   }
-  for (let i = 0; i < raw.length; i++) {
-    const c = raw.charCodeAt(i);
+
+  if (raw.includes("..") || decoded.includes("..") || raw.includes("\\") || decoded.includes("\\")) {
+    throw new Error("path must not contain '..' or '\\'");
+  }
+  for (let i = 0; i < decoded.length; i++) {
+    const c = decoded.charCodeAt(i);
     if (c < 0x20 || c === 0x7f) {
       throw new Error("path must not contain control characters");
     }

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -53,6 +53,33 @@ async function main(): Promise<void> {
   }
   assert("security: reject path traversal", travOk);
 
+  let encodedTravOk = true;
+  try {
+    normalizePath("/servers/%2e%2e/%2e%2e/admin");
+    encodedTravOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject percent-encoded path traversal", encodedTravOk);
+
+  let backslashOk = true;
+  try {
+    normalizePath("/servers/..\\admin");
+    backslashOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject backslashes", backslashOk);
+
+  let encodedBackslashOk = true;
+  try {
+    normalizePath("/servers/..%5cadmin");
+    encodedBackslashOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject percent-encoded backslashes", encodedBackslashOk);
+
   // Cost guard unit checks (no network). Billed creates and billed actions must be flagged,
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
   const costChecks = [
@@ -73,8 +100,14 @@ async function main(): Promise<void> {
     await check("robot /server", "robot", "/server"),
   ];
   const passed =
-    results.filter(Boolean).length + (secOk ? 1 : 0) + (travOk ? 1 : 0) + costChecks.filter(Boolean).length;
-  const total = results.length + 2 + costChecks.length;
+    results.filter(Boolean).length +
+    (secOk ? 1 : 0) +
+    (travOk ? 1 : 0) +
+    (encodedTravOk ? 1 : 0) +
+    (backslashOk ? 1 : 0) +
+    (encodedBackslashOk ? 1 : 0) +
+    costChecks.filter(Boolean).length;
+  const total = results.length + 5 + costChecks.length;
   process.stdout.write(`\n${passed}/${total} checks passed\n`);
   if (passed !== total) process.exitCode = 1;
 }


### PR DESCRIPTION
This PR hardens the path normalization logic in `src/security.ts` to prevent SSRF and path traversal vulnerabilities through percent-encoded characters or backslashes.

### 🚨 Severity
MEDIUM

### 💡 Vulnerability
The `normalizePath` utility was checking for raw `..` sequences, but it did not decode percent-encoded characters before validating. In a Node environment, a path like `/%2e%2e/%2e%2e/` or `/..%5c` could be normalized or processed into path traversal segments by the underlying WHATWG URL implementation, risking SSRF or directory traversal.

### 🎯 Impact
Maliciously crafted path parameters from clients could bypass the relative-only constraint, potentially pointing the HTTP client to unauthorized internal resources or other endpoints.

### 🔧 Fix
1. Decoded the raw path parameter using `decodeURIComponent` in `normalizePath`.
2. Explicitly checked the decoded path for both `..` and `\`.
3. Added robust try-catch handling for malformed percent-encoding.
4. Added new test cases in `test/smoke.ts` verifying the correct rejection of percent-encoded dot-dots, backslashes, and percent-encoded backslashes.

### ✅ Verification
Tested locally with `npm run typecheck` and `npm run smoke`. All security assertions passed correctly.

---
*PR created automatically by Jules for task [5500842015443759557](https://jules.google.com/task/5500842015443759557) started by @mjmirza*