### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Prevent percent-encoded and backslash path traversal bypasses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-08 - Path Traversal & SSRF Prevention with WHATWG URL Parsing
+**Vulnerability:** Node's WHATWG `URL` parser automatically normalizes backslashes (`\`) to forward slashes (`/`), and decodes percent-encoded characters like `%2e` to `.` before resolving path relative segments. This can bypass naive string-level checks like `.includes('..')` if the check runs on the raw input string, allowing path traversal or Server-Side Request Forgery (SSRF).
+**Learning:** To safely prevent path traversal and SSRF, path validation must decode the path via `decodeURIComponent` and explicitly check for both `..` and `\` before passing the value to the `URL` constructor or other URL parsers.
+**Prevention:** Always sanitize inputs with `decodeURIComponent` first, check for traversal patterns such as `..` and backslashes `\`, and only then construct the URLs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hetzner-mcp",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hetzner-mcp",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/security.ts
+++ b/src/security.ts
@@ -19,8 +19,17 @@ export function normalizePath(path: string): string {
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw) || raw.startsWith("//")) {
     throw new Error("path must be a relative API path like /servers, not a full URL");
   }
-  if (raw.includes("..")) {
-    throw new Error("path must not contain '..'");
+  // Decode URL components to prevent percent-encoded bypasses (e.g., %2e%2e)
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    throw new Error("path contains malformed URI encoding");
+  }
+
+  // Reject both standard dot-dot and any backslashes which can normalize to slashes
+  if (decoded.includes("..") || decoded.includes("\\")) {
+    throw new Error("path must not contain '..' or backslashes");
   }
   for (let i = 0; i < raw.length; i++) {
     const c = raw.charCodeAt(i);

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -53,6 +53,24 @@ async function main(): Promise<void> {
   }
   assert("security: reject path traversal", travOk);
 
+  let pcertOk = true;
+  try {
+    normalizePath("/servers/%2e%2e/%2e%2e/admin");
+    pcertOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject percent-encoded traversal", pcertOk);
+
+  let bsOk = true;
+  try {
+    normalizePath("/servers/..\\..\\admin");
+    bsOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject backslash traversal", bsOk);
+
   // Cost guard unit checks (no network). Billed creates and billed actions must be flagged,
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
   const costChecks = [
@@ -73,8 +91,13 @@ async function main(): Promise<void> {
     await check("robot /server", "robot", "/server"),
   ];
   const passed =
-    results.filter(Boolean).length + (secOk ? 1 : 0) + (travOk ? 1 : 0) + costChecks.filter(Boolean).length;
-  const total = results.length + 2 + costChecks.length;
+    results.filter(Boolean).length +
+    (secOk ? 1 : 0) +
+    (travOk ? 1 : 0) +
+    (pcertOk ? 1 : 0) +
+    (bsOk ? 1 : 0) +
+    costChecks.filter(Boolean).length;
+  const total = results.length + 4 + costChecks.length;
   process.stdout.write(`\n${passed}/${total} checks passed\n`);
   if (passed !== total) process.exitCode = 1;
 }


### PR DESCRIPTION
In Node's WHATWG URL implementation, backslashes are normalized to forward slashes and percent-encoded dot-dot segments (e.g. `%2e%2e`) are resolved to dot-dot path navigation. Standard checks looking only for `..` on raw string paths can be easily bypassed. This patch decodes the input via `decodeURIComponent` first, then explicitly checks and rejects path traversal sequences and backslashes. Unit/smoke tests are added to verify the validation behaves correctly.

---
*PR created automatically by Jules for task [4818097774019990826](https://jules.google.com/task/4818097774019990826) started by @mjmirza*