### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix percent-encoded path traversal and SSRF bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-07 - WHATWG URL Percent-Encoded Path Traversal and SSRF Bypass
+**Vulnerability:** Node's WHATWG URL implementation normalizes backslashes `\` to `/` and resolves percent-encoded dots (like `%2e%2e` or `%2E%2E`) into dot-dot path segments during parsing. When checking strings raw before passing them to the URL constructor, standard substring checks (like `.includes('..')` or `.includes('\\')`) can be bypassed via URL encoding or backslashes.
+**Learning:** Checking raw input paths for dangerous sequences without decoding them first is insufficient because downstream URL parsers and normalized HTTP clients will decode and normalize these inputs, re-introducing the vulnerability.
+**Prevention:** Always decode input paths using `decodeURIComponent` (or appropriate URL/URI decoders) prior to performing path validation, and explicitly reject both raw and decoded strings containing path traversal (`..`), backslashes (`\`), or control characters.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hetzner-mcp",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hetzner-mcp",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/security.ts
+++ b/src/security.ts
@@ -9,7 +9,8 @@ const WRITE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 /**
  * Normalize and validate a relative API path.
- * Rejects full URLs, protocol-relative URLs, path traversal, and control characters.
+ * Rejects full URLs, protocol-relative URLs, path traversal, backslashes, and control characters.
+ * Decodes path components to prevent percent-encoded bypasses of safety checks.
  */
 export function normalizePath(path: string): string {
   if (typeof path !== "string" || path.trim().length === 0) {
@@ -19,15 +20,35 @@ export function normalizePath(path: string): string {
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw) || raw.startsWith("//")) {
     throw new Error("path must be a relative API path like /servers, not a full URL");
   }
-  if (raw.includes("..")) {
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    throw new Error("path must not contain malformed percent encoding");
+  }
+
+  if (raw.includes("..") || decoded.includes("..")) {
     throw new Error("path must not contain '..'");
   }
+  if (raw.includes("\\") || decoded.includes("\\")) {
+    throw new Error("path must not contain '\\'");
+  }
+
   for (let i = 0; i < raw.length; i++) {
     const c = raw.charCodeAt(i);
     if (c < 0x20 || c === 0x7f) {
       throw new Error("path must not contain control characters");
     }
   }
+
+  for (let i = 0; i < decoded.length; i++) {
+    const c = decoded.charCodeAt(i);
+    if (c < 0x20 || c === 0x7f) {
+      throw new Error("path must not contain control characters");
+    }
+  }
+
   return raw.startsWith("/") ? raw : "/" + raw;
 }
 

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -53,6 +53,60 @@ async function main(): Promise<void> {
   }
   assert("security: reject path traversal", travOk);
 
+  let encTravOk1 = true;
+  try {
+    normalizePath("/servers/%2e%2e/%2e%2e/admin");
+    encTravOk1 = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject URL-encoded path traversal (%2e%2e)", encTravOk1);
+
+  let encTravOk2 = true;
+  try {
+    normalizePath("/servers/%2E%2E/%2E%2E/admin");
+    encTravOk2 = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject URL-encoded path traversal (%2E%2E)", encTravOk2);
+
+  let backslashOk1 = true;
+  try {
+    normalizePath("/servers\\..\\..\\admin");
+    backslashOk1 = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject backslash path traversal", backslashOk1);
+
+  let backslashOk2 = true;
+  try {
+    normalizePath("/servers%5c..%5c..%5cadmin");
+    backslashOk2 = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject URL-encoded backslash path traversal", backslashOk2);
+
+  let malformedPercentOk = true;
+  try {
+    normalizePath("/servers/%zz");
+    malformedPercentOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject malformed percent encoding", malformedPercentOk);
+
+  let ctrlCharOk = true;
+  try {
+    normalizePath("/servers/%00admin");
+    ctrlCharOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject URL-encoded control character", ctrlCharOk);
+
   // Cost guard unit checks (no network). Billed creates and billed actions must be flagged,
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
   const costChecks = [
@@ -72,9 +126,19 @@ async function main(): Promise<void> {
     await check("storagebox /storage_box_types", "storagebox", "/storage_box_types"),
     await check("robot /server", "robot", "/server"),
   ];
+  const secChecks = [
+    secOk,
+    travOk,
+    encTravOk1,
+    encTravOk2,
+    backslashOk1,
+    backslashOk2,
+    malformedPercentOk,
+    ctrlCharOk,
+  ];
   const passed =
-    results.filter(Boolean).length + (secOk ? 1 : 0) + (travOk ? 1 : 0) + costChecks.filter(Boolean).length;
-  const total = results.length + 2 + costChecks.length;
+    results.filter(Boolean).length + secChecks.filter(Boolean).length + costChecks.filter(Boolean).length;
+  const total = results.length + secChecks.length + costChecks.length;
   process.stdout.write(`\n${passed}/${total} checks passed\n`);
   if (passed !== total) process.exitCode = 1;
 }


### PR DESCRIPTION
🚨 Severity: HIGH/CRITICAL
💡 Vulnerability: Node's WHATWG URL implementation normalizes backslashes '\' to '/' and resolves percent-encoded dots (such as '%2e%2e' or '%2E%2E') to dot-dot segments during parsing. Standard checks on raw strings (such as raw.includes('..') or raw.includes('\\')) can be bypassed via URL encoding or backslashes.
🎯 Impact: Attackers could craft API paths that bypass path-traversal/SSRF checks, pointing the MCP server at arbitrary endpoints.
🔧 Fix: Decoded the input path using decodeURIComponent inside normalizePath in src/security.ts, and added explicit checks for both raw and decoded strings containing path-traversal (..), backslashes (\), or control characters.
✅ Verification: Added comprehensive unit tests in test/smoke.ts verifying that all edge cases (like %2e%2e, %2E%2E, %5c, and control characters) are correctly rejected. All 14 security and cost checks passed successfully.

---
*PR created automatically by Jules for task [16577606940666042083](https://jules.google.com/task/16577606940666042083) started by @mjmirza*