### PR TITLE
🛡️ Sentinel: Fix path traversal and SSRF bypass in normalizePath

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Security Journal - Critical learnings only
+
+## 2026-08-07 - Path Traversal and SSRF Bypass via Percent-Encoded Dot-Dot-Slash and Backslash Normalization in WHATWG URL Parsing
+**Vulnerability:** Node's WHATWG URL implementation normalizes backslashes `\` to `/` and resolves percent-encoded dots (like `%2e%2e`) to dot-dot segments during URL parsing. If a path traversal check is done prior to URL decoding, an attacker can pass paths like `/servers/%2e%2e/%2e%2e/pricing` or `/servers/..\\pricing` to bypass simple string verification. When the `new URL(...)` is constructed, these resolve to path traversals and could lead to SSRF or unauthorized endpoint access.
+**Learning:** Checking for path traversal on raw input strings is insufficient because URL decoders and WHATWG URL parser normalization can transform characters after the validation check. Path validation must always decode the path via `decodeURIComponent` and explicitly check for both `..` and `\`.
+**Prevention:** Always decode user input via `decodeURIComponent` (catching any potential `URIError` for malformed percent encoding) prior to executing safety checks, and perform explicit checks against blocklist characters like `..` and `\` on the decoded result.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hetzner-mcp",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hetzner-mcp",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/security.ts
+++ b/src/security.ts
@@ -19,11 +19,25 @@ export function normalizePath(path: string): string {
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw) || raw.startsWith("//")) {
     throw new Error("path must be a relative API path like /servers, not a full URL");
   }
-  if (raw.includes("..")) {
+
+  // To safely prevent path traversal and SSRF, path validation must decode the path via
+  // decodeURIComponent and explicitly check for both ".." and "\".
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    throw new Error("path must not contain malformed percent encoding");
+  }
+
+  if (decoded.includes("..")) {
     throw new Error("path must not contain '..'");
   }
-  for (let i = 0; i < raw.length; i++) {
-    const c = raw.charCodeAt(i);
+  if (decoded.includes("\\")) {
+    throw new Error("path must not contain '\\'");
+  }
+
+  for (let i = 0; i < decoded.length; i++) {
+    const c = decoded.charCodeAt(i);
     if (c < 0x20 || c === 0x7f) {
       throw new Error("path must not contain control characters");
     }

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -53,6 +53,33 @@ async function main(): Promise<void> {
   }
   assert("security: reject path traversal", travOk);
 
+  let encTravOk = true;
+  try {
+    normalizePath("/servers/%2e%2e/%2e%2e/pricing");
+    encTravOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject percent-encoded path traversal", encTravOk);
+
+  let backslashOk = true;
+  try {
+    normalizePath("/servers/..\\pricing");
+    backslashOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject backslash path traversal", backslashOk);
+
+  let malformedPercentOk = true;
+  try {
+    normalizePath("/servers/%");
+    malformedPercentOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject malformed percent encoding", malformedPercentOk);
+
   // Cost guard unit checks (no network). Billed creates and billed actions must be flagged,
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
   const costChecks = [
@@ -73,8 +100,14 @@ async function main(): Promise<void> {
     await check("robot /server", "robot", "/server"),
   ];
   const passed =
-    results.filter(Boolean).length + (secOk ? 1 : 0) + (travOk ? 1 : 0) + costChecks.filter(Boolean).length;
-  const total = results.length + 2 + costChecks.length;
+    results.filter(Boolean).length +
+    (secOk ? 1 : 0) +
+    (travOk ? 1 : 0) +
+    (encTravOk ? 1 : 0) +
+    (backslashOk ? 1 : 0) +
+    (malformedPercentOk ? 1 : 0) +
+    costChecks.filter(Boolean).length;
+  const total = results.length + 5 + costChecks.length;
   process.stdout.write(`\n${passed}/${total} checks passed\n`);
   if (passed !== total) process.exitCode = 1;
 }


### PR DESCRIPTION
This PR secures the `normalizePath` validation logic in `src/security.ts`. Previously, path traversal validation did not decode raw URI components or filter backslashes, allowing potential bypasses using percent-encoded characters (like `%2e%2e` for `..`) or backslashes (`\`) which the Node.js WHATWG URL implementation normalizes. We now decode the path via `decodeURIComponent` first, check for malformed percent encoding, and explicitly reject `..` and `\`. Unit tests have been added to `test/smoke.ts` and successfully verified, and a Sentinel journal entry has been created under `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [17855077503939580308](https://jules.google.com/task/17855077503939580308) started by @mjmirza*