### PR TITLE
🛡️ Sentinel: Fix path traversal and SSRF bypass in normalizePath

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Security Journal
+
+## 2026-06-07 - Path Traversal & SSRF Bypass via WHATWG URL Normalization and URL Percent Encoding
+**Vulnerability:** In Node's WHATWG URL parser, backslashes (`\`) are normalized to forward slashes (`/`), and percent-encoded dots (such as `%2e%2e` or `%2E%2E`) are resolved to dot-dot segments during parsing. When only raw path strings are checked for `..`, an attacker can bypass the path traversal check by using backslashes or percent encoding, resulting in path traversal or SSRF on the destination server.
+**Learning:** Checking relative paths for substrings like `..` without first decoding and normalizing them is insufficient. Node's WHATWG URL parser performs normalizations (decoding percent-encoded dots and converting backslashes) after the check, which leads to path traversal.
+**Prevention:** Always decode paths using `decodeURIComponent` (catching and rejecting any malformed percent encoding) and explicitly reject both `..` and `\` characters in both the raw and decoded inputs before constructing a WHATWG URL.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hetzner-mcp",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hetzner-mcp",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/security.ts
+++ b/src/security.ts
@@ -19,15 +19,37 @@ export function normalizePath(path: string): string {
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw) || raw.startsWith("//")) {
     throw new Error("path must be a relative API path like /servers, not a full URL");
   }
-  if (raw.includes("..")) {
-    throw new Error("path must not contain '..'");
+
+  // To prevent path traversal and SSRF, decode the path first.
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch (err) {
+    throw new Error("path must not contain malformed percent encoding");
   }
+
+  // Re-check for control characters in both raw and decoded strings.
   for (let i = 0; i < raw.length; i++) {
     const c = raw.charCodeAt(i);
     if (c < 0x20 || c === 0x7f) {
       throw new Error("path must not contain control characters");
     }
   }
+  for (let i = 0; i < decoded.length; i++) {
+    const c = decoded.charCodeAt(i);
+    if (c < 0x20 || c === 0x7f) {
+      throw new Error("path must not contain control characters");
+    }
+  }
+
+  // Reject path traversal with '..' or backslashes '\'.
+  if (decoded.includes("..") || decoded.includes("\\")) {
+    throw new Error("path must not contain '..' or '\\'");
+  }
+  if (raw.includes("..") || raw.includes("\\")) {
+    throw new Error("path must not contain '..' or '\\'");
+  }
+
   return raw.startsWith("/") ? raw : "/" + raw;
 }
 

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -53,6 +53,32 @@ async function main(): Promise<void> {
   }
   assert("security: reject path traversal", travOk);
 
+  // New path traversal and SSRF bypass checks
+  const badPaths = [
+    "/servers/..\\admin",
+    "/servers\\admin",
+    "/servers/%2e%2e/admin",
+    "/servers/%2E%2E/admin",
+    "/servers/.%2e/admin",
+    "/servers/%2e./admin",
+    "/servers/..%5cadmin",
+    "/servers/..%5Cadmin",
+    "%2e%2e%5cadmin",
+    "/%invalid",
+    "/servers/%00admin",
+  ];
+  let bypassOk = true;
+  for (const bp of badPaths) {
+    try {
+      normalizePath(bp);
+      bypassOk = false;
+      console.error(`FAIL: expected path to be rejected: ${bp}`);
+    } catch {
+      /* expected */
+    }
+  }
+  assert("security: reject traversal/backslash/SSRF bypasses", bypassOk);
+
   // Cost guard unit checks (no network). Billed creates and billed actions must be flagged,
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
   const costChecks = [
@@ -73,8 +99,8 @@ async function main(): Promise<void> {
     await check("robot /server", "robot", "/server"),
   ];
   const passed =
-    results.filter(Boolean).length + (secOk ? 1 : 0) + (travOk ? 1 : 0) + costChecks.filter(Boolean).length;
-  const total = results.length + 2 + costChecks.length;
+    results.filter(Boolean).length + (secOk ? 1 : 0) + (travOk ? 1 : 0) + (bypassOk ? 1 : 0) + costChecks.filter(Boolean).length;
+  const total = results.length + 3 + costChecks.length;
   process.stdout.write(`\n${passed}/${total} checks passed\n`);
   if (passed !== total) process.exitCode = 1;
 }


### PR DESCRIPTION
🚨 Severity: HIGH/CRITICAL
💡 Vulnerability: Node's WHATWG URL parser normalizes backslashes to forward slashes and resolves percent-encoded dots (such as %2e%2e) to dot-dot segments during parsing. Since normalizePath only checked raw paths, an attacker could bypass the traversal validation and achieve path traversal or SSRF on the destination server.
🎯 Impact: Attackers could access unauthorized API endpoints on Hetzner or make requests to unwanted destinations.
🔧 Fix: Decoded paths using `decodeURIComponent` inside `normalizePath` and explicitly rejected both raw/decoded instances of `..` and `\`, as well as malformed percent encodings.
✅ Verification: Expanded the smoke test suite with 11 distinct path traversal and SSRF bypass inputs and verified they are all correctly rejected.

---
*PR created automatically by Jules for task [17702899256314085108](https://jules.google.com/task/17702899256314085108) started by @mjmirza*