### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix path traversal and SSRF via percent-encoded URI segments

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-08-13 - Path Traversal & SSRF bypass via encoded URI segments in URL parsing
+**Vulnerability:** Attackers could bypass path validation checks by utilizing percent-encoded dot-dots (`%2e%2e`) or percent-encoded backslashes (`%5c`) in API paths. Node.js's WHATWG URL parser automatically normalizes backslashes to forward slashes and resolves decoded dot-dots during URL instantiation, allowing path traversal / SSRF to arbitrary endpoints even if raw string checks look for `..`.
+**Learning:** Checking raw, undecoded path strings for characters like `..` is insufficient when those paths are later passed into standard URL parsing libraries (like WHATWG `URL`) that decode or normalize percent-encoded sequences or backslashes during construction.
+**Prevention:** Always decode user-provided URL path segments using `decodeURIComponent` (and handle any malformed percent-encoding errors) before conducting blocklist checks like containing `..` or `\`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hetzner-mcp",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hetzner-mcp",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/security.ts
+++ b/src/security.ts
@@ -19,9 +19,23 @@ export function normalizePath(path: string): string {
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw) || raw.startsWith("//")) {
     throw new Error("path must be a relative API path like /servers, not a full URL");
   }
-  if (raw.includes("..")) {
+
+  // To prevent path traversal and SSRF via URL normalization,
+  // we decode the URI and explicitly check for both '..' and '\'.
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch (err) {
+    throw new Error("path contains malformed percent-encoding");
+  }
+
+  if (decoded.includes("..")) {
     throw new Error("path must not contain '..'");
   }
+  if (decoded.includes("\\")) {
+    throw new Error("path must not contain '\\'");
+  }
+
   for (let i = 0; i < raw.length; i++) {
     const c = raw.charCodeAt(i);
     if (c < 0x20 || c === 0x7f) {

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -53,6 +53,34 @@ async function main(): Promise<void> {
   }
   assert("security: reject path traversal", travOk);
 
+  // New path traversal checks including percent-encoded dot-dots and backslashes
+  let encodedTravOk = true;
+  try {
+    normalizePath("/v1/%2e%2e/pricing");
+    encodedTravOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject encoded path traversal", encodedTravOk);
+
+  let backslashTravOk = true;
+  try {
+    normalizePath("/v1/%2e%2e%5cpricing");
+    backslashTravOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject encoded backslash path traversal", backslashTravOk);
+
+  let malformedPercentOk = true;
+  try {
+    normalizePath("/v1/%ffff/pricing");
+    malformedPercentOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject malformed percent-encoding", malformedPercentOk);
+
   // Cost guard unit checks (no network). Billed creates and billed actions must be flagged,
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
   const costChecks = [
@@ -73,8 +101,14 @@ async function main(): Promise<void> {
     await check("robot /server", "robot", "/server"),
   ];
   const passed =
-    results.filter(Boolean).length + (secOk ? 1 : 0) + (travOk ? 1 : 0) + costChecks.filter(Boolean).length;
-  const total = results.length + 2 + costChecks.length;
+    results.filter(Boolean).length +
+    (secOk ? 1 : 0) +
+    (travOk ? 1 : 0) +
+    (encodedTravOk ? 1 : 0) +
+    (backslashTravOk ? 1 : 0) +
+    (malformedPercentOk ? 1 : 0) +
+    costChecks.filter(Boolean).length;
+  const total = results.length + 5 + costChecks.length;
   process.stdout.write(`\n${passed}/${total} checks passed\n`);
   if (passed !== total) process.exitCode = 1;
 }


### PR DESCRIPTION
Fixed a vulnerability in path normalization where percent-encoded dot-dot (`%2e%2e`) and backslash (`%5c`) sequences could bypass the path validation and cause path traversal or SSRF when parsed into WHATWG URLs. Decodes paths prior to verification and handles malformed sequences gracefully.

---
*PR created automatically by Jules for task [4230837537611114191](https://jules.google.com/task/4230837537611114191) started by @mjmirza*