### PR TITLE
🛡️ Sentinel: Fix path traversal bypass via percent encoding and backslashes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hetzner-mcp",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hetzner-mcp",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/security.ts
+++ b/src/security.ts
@@ -9,7 +9,8 @@ const WRITE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 /**
  * Normalize and validate a relative API path.
- * Rejects full URLs, protocol-relative URLs, path traversal, and control characters.
+ * Rejects full URLs, protocol-relative URLs, path traversal, backslashes, and control characters.
+ * Decodes URL components to prevent path traversal via percent encoding (e.g., %2e%2e).
  */
 export function normalizePath(path: string): string {
   if (typeof path !== "string" || path.trim().length === 0) {
@@ -19,8 +20,14 @@ export function normalizePath(path: string): string {
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw) || raw.startsWith("//")) {
     throw new Error("path must be a relative API path like /servers, not a full URL");
   }
-  if (raw.includes("..")) {
-    throw new Error("path must not contain '..'");
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    throw new Error("path contains invalid percent encoding");
+  }
+  if (raw.includes("..") || raw.includes("\\") || decoded.includes("..") || decoded.includes("\\")) {
+    throw new Error("path must not contain '..' or '\\'");
   }
   for (let i = 0; i < raw.length; i++) {
     const c = raw.charCodeAt(i);

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -53,6 +53,33 @@ async function main(): Promise<void> {
   }
   assert("security: reject path traversal", travOk);
 
+  let encTravOk = true;
+  try {
+    normalizePath("/servers/%2e%2e/admin");
+    encTravOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject encoded path traversal (%2e%2e)", encTravOk);
+
+  let bsOk = true;
+  try {
+    normalizePath("/servers\\admin");
+    bsOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject backslash in path", bsOk);
+
+  let invEncOk = true;
+  try {
+    normalizePath("/servers/%ff/admin");
+    invEncOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject invalid percent encoding", invEncOk);
+
   // Cost guard unit checks (no network). Billed creates and billed actions must be flagged,
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
   const costChecks = [
@@ -73,8 +100,14 @@ async function main(): Promise<void> {
     await check("robot /server", "robot", "/server"),
   ];
   const passed =
-    results.filter(Boolean).length + (secOk ? 1 : 0) + (travOk ? 1 : 0) + costChecks.filter(Boolean).length;
-  const total = results.length + 2 + costChecks.length;
+    results.filter(Boolean).length +
+    (secOk ? 1 : 0) +
+    (travOk ? 1 : 0) +
+    (encTravOk ? 1 : 0) +
+    (bsOk ? 1 : 0) +
+    (invEncOk ? 1 : 0) +
+    costChecks.filter(Boolean).length;
+  const total = results.length + 5 + costChecks.length;
   process.stdout.write(`\n${passed}/${total} checks passed\n`);
   if (passed !== total) process.exitCode = 1;
 }


### PR DESCRIPTION
Enhances path normalization in `src/security.ts` by decoding URL components before checking for path traversal segments (`..`) or backslashes (`\`). This prevents potential path traversal and SSRF bypasses via percent-encoding (e.g. `%2e%2e`) or backslashes when resolved by Node's WHATWG `URL` parser. Adds unit tests in `test/smoke.ts` to verify protection.

---
*PR created automatically by Jules for task [8703365931631123238](https://jules.google.com/task/8703365931631123238) started by @mjmirza*