### PR TITLE
🛡️ Sentinel: Fix path traversal and SSRF bypass in path normalization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hetzner-mcp",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hetzner-mcp",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/security.ts
+++ b/src/security.ts
@@ -19,11 +19,30 @@ export function normalizePath(path: string): string {
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw) || raw.startsWith("//")) {
     throw new Error("path must be a relative API path like /servers, not a full URL");
   }
-  if (raw.includes("..")) {
-    throw new Error("path must not contain '..'");
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    throw new Error("path contains invalid percent encoding");
   }
+
+  if (
+    raw.includes("..") ||
+    raw.includes("\\") ||
+    decoded.includes("..") ||
+    decoded.includes("\\")
+  ) {
+    throw new Error("path must not contain '..' or '\\'");
+  }
+
   for (let i = 0; i < raw.length; i++) {
     const c = raw.charCodeAt(i);
+    if (c < 0x20 || c === 0x7f) {
+      throw new Error("path must not contain control characters");
+    }
+  }
+  for (let i = 0; i < decoded.length; i++) {
+    const c = decoded.charCodeAt(i);
     if (c < 0x20 || c === 0x7f) {
       throw new Error("path must not contain control characters");
     }

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -51,6 +51,18 @@ async function main(): Promise<void> {
   } catch {
     /* expected */
   }
+  try {
+    normalizePath("/%2e%2e/admin");
+    travOk = false;
+  } catch {
+    /* expected */
+  }
+  try {
+    normalizePath("/foo\\..\\bar");
+    travOk = false;
+  } catch {
+    /* expected */
+  }
   assert("security: reject path traversal", travOk);
 
   // Cost guard unit checks (no network). Billed creates and billed actions must be flagged,


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Path Traversal and SSRF Bypass in path normalization

- 🚨 Severity: HIGH
- 💡 Vulnerability: `normalizePath` previously only checked for raw `".."` substrings, leaving it open to percent-encoded path traversal sequences (such as `/%2e%2e/admin`) or backslashes (`/foo\..\bar`). When passed to Node's `new URL()`, percent-encoded dot segments and backslashes are resolved/normalized, allowing path traversal / SSRF bypass.
- 🎯 Impact: An attacker could bypass path restrictions to access arbitrary endpoints on Hetzner API surfaces or cause SSRF.
- 🔧 Fix: Updated `normalizePath` in `src/security.ts` to decode percent-encoding via `decodeURIComponent` and reject path traversal sequences (`..`) and backslashes (`\`) in both raw and decoded path strings, while handling invalid percent-encoding safely.
- ✅ Verification: Added unit test assertions in `test/smoke.ts` and confirmed that typecheck, build, and unit tests pass.

---
*PR created automatically by Jules for task [12698487963966455266](https://jules.google.com/task/12698487963966455266) started by @mjmirza*