### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal and SSRF bypass via URL-encoding and backslashes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-18 - Prevent Path Traversal and SSRF via URL Percent-Encoding and Backslashes
+**Vulnerability:** Input paths passed to `normalizePath` containing percent-encoded sequences like `%2e%2e` or backslashes `\` bypassed path traversal checks because `normalizePath` checked `raw.includes("..")` on undecoded strings without inspecting decoded URL segments or backslashes.
+**Learning:** Node's WHATWG `URL` constructor normalizes backslashes to slashes (`\evil.com` -> `//evil.com`) and resolves percent-encoded dots (`%2e%2e`) into dot-dot path segments during parsing, which can lead to SSRF or path traversal when constructed via `new URL(base + path)`.
+**Prevention:** Always decode URL paths using `decodeURIComponent` before performing validation checks, explicitly check for both `..` and `\`, and reject malformed percent-encoding strings.

--- a/src/security.ts
+++ b/src/security.ts
@@ -19,11 +19,23 @@ export function normalizePath(path: string): string {
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw) || raw.startsWith("//")) {
     throw new Error("path must be a relative API path like /servers, not a full URL");
   }
-  if (raw.includes("..")) {
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    throw new Error("path contains malformed percent-encoding");
+  }
+
+  if (decoded.includes("..") || raw.includes("..")) {
     throw new Error("path must not contain '..'");
   }
-  for (let i = 0; i < raw.length; i++) {
-    const c = raw.charCodeAt(i);
+  if (decoded.includes("\\") || raw.includes("\\")) {
+    throw new Error("path must not contain backslashes");
+  }
+
+  for (let i = 0; i < decoded.length; i++) {
+    const c = decoded.charCodeAt(i);
     if (c < 0x20 || c === 0x7f) {
       throw new Error("path must not contain control characters");
     }

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -53,6 +53,33 @@ async function main(): Promise<void> {
   }
   assert("security: reject path traversal", travOk);
 
+  let encTravOk = true;
+  try {
+    normalizePath("/servers/%2e%2e/admin");
+    encTravOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject encoded path traversal", encTravOk);
+
+  let backslashOk = true;
+  try {
+    normalizePath("/\\evil.com");
+    backslashOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject backslashes", backslashOk);
+
+  let malformedOk = true;
+  try {
+    normalizePath("/servers/%FF/test");
+    malformedOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject malformed percent-encoding", malformedOk);
+
   // Cost guard unit checks (no network). Billed creates and billed actions must be flagged,
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
   const costChecks = [
@@ -72,9 +99,10 @@ async function main(): Promise<void> {
     await check("storagebox /storage_box_types", "storagebox", "/storage_box_types"),
     await check("robot /server", "robot", "/server"),
   ];
+  const secUnitPassed = [secOk, travOk, encTravOk, backslashOk, malformedOk].filter(Boolean).length;
   const passed =
-    results.filter(Boolean).length + (secOk ? 1 : 0) + (travOk ? 1 : 0) + costChecks.filter(Boolean).length;
-  const total = results.length + 2 + costChecks.length;
+    results.filter(Boolean).length + secUnitPassed + costChecks.filter(Boolean).length;
+  const total = results.length + 5 + costChecks.length;
   process.stdout.write(`\n${passed}/${total} checks passed\n`);
   if (passed !== total) process.exitCode = 1;
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix path traversal and SSRF bypass via URL-encoding and backslashes

🚨 Severity: HIGH
💡 Vulnerability: `normalizePath` checked for path traversal using `raw.includes("..")` without URL-decoding input paths or checking backslashes `\`.
🎯 Impact: Attackers could pass percent-encoded dot segments (`%2e%2e`) or backslashes to bypass the path traversal check, which `new URL()` would resolve into path traversal or domain redirection.
🔧 Fix: Enhanced `normalizePath` in `src/security.ts` to decode paths with `decodeURIComponent`, reject `..` and `\`, and reject malformed percent encodings or control characters.
✅ Verification: Expanded `test/smoke.ts` unit assertions to verify rejection of encoded path traversal (`%2e%2e`), backslashes (`\`), and malformed percent encodings (`%FF`).

---
*PR created automatically by Jules for task [1406490669295998455](https://jules.google.com/task/1406490669295998455) started by @mjmirza*