### PR TITLE
🛡️ Sentinel: [HIGH] Fix URI-encoded path traversal and backslash evasion in path normalization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-07 - Node WHATWG URL Encoded Path Traversal and Backslash Evasion
+**Vulnerability:** API path validation previously performed a simple check for `".."`, which failed to reject percent-encoded dot segments (e.g. `"%2e%2e"`) and backslashes (e.g. `"\\"` or `"%5c"`). When concatenated with a base URL, Node's WHATWG URL parser resolved percent-encoded dot segments and normalized backslashes to forward slashes, enabling path traversal out of the API prefix.
+**Learning:** Checking raw strings for `".."` is insufficient when the string is later parsed by URL parsers like WHATWG `URL`, which normalize `\` to `/` and resolve `%2e%2e` dot segments.
+**Prevention:** Always decode paths using `decodeURIComponent()` before validation and explicitly reject both `".."` and `"\\"` in raw and decoded forms, as well as handling malformed percent encodings.

--- a/src/security.ts
+++ b/src/security.ts
@@ -22,8 +22,23 @@ export function normalizePath(path: string): string {
   if (raw.includes("..")) {
     throw new Error("path must not contain '..'");
   }
-  for (let i = 0; i < raw.length; i++) {
-    const c = raw.charCodeAt(i);
+  if (raw.includes("\\")) {
+    throw new Error("path must not contain '\\'");
+  }
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    throw new Error("path contains malformed percent encoding");
+  }
+  if (decoded.includes("..")) {
+    throw new Error("path must not contain '..'");
+  }
+  if (decoded.includes("\\")) {
+    throw new Error("path must not contain '\\'");
+  }
+  for (let i = 0; i < decoded.length; i++) {
+    const c = decoded.charCodeAt(i);
     if (c < 0x20 || c === 0x7f) {
       throw new Error("path must not contain control characters");
     }

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -53,6 +53,44 @@ async function main(): Promise<void> {
   }
   assert("security: reject path traversal", travOk);
 
+  let encTravOk = true;
+  try {
+    normalizePath("/%2e%2e/admin");
+    encTravOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject encoded path traversal", encTravOk);
+
+  let backslashOk = true;
+  try {
+    normalizePath("/servers\\..\\admin");
+    backslashOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject backslash in path", backslashOk);
+
+  let encBackslashOk = true;
+  try {
+    normalizePath("/servers/%5c../admin");
+    encBackslashOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject encoded backslash", encBackslashOk);
+
+  let malformedOk = true;
+  try {
+    normalizePath("/%ff");
+    malformedOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject malformed encoding", malformedOk);
+
+  const secChecks = [secOk, travOk, encTravOk, backslashOk, encBackslashOk, malformedOk];
+
   // Cost guard unit checks (no network). Billed creates and billed actions must be flagged,
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
   const costChecks = [
@@ -73,8 +111,10 @@ async function main(): Promise<void> {
     await check("robot /server", "robot", "/server"),
   ];
   const passed =
-    results.filter(Boolean).length + (secOk ? 1 : 0) + (travOk ? 1 : 0) + costChecks.filter(Boolean).length;
-  const total = results.length + 2 + costChecks.length;
+    results.filter(Boolean).length +
+    secChecks.filter(Boolean).length +
+    costChecks.filter(Boolean).length;
+  const total = results.length + secChecks.length + costChecks.length;
   process.stdout.write(`\n${passed}/${total} checks passed\n`);
   if (passed !== total) process.exitCode = 1;
 }


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Fix URI-encoded path traversal and backslash evasion in path normalization

- **🚨 Severity:** HIGH
- **💡 Vulnerability:** `normalizePath()` checked only raw strings for `".."` without decoding percent-encoded dot segments (e.g., `"%2e%2e"`) or checking backslashes (`"\\"` or `"%5c"`). When passed to Node's WHATWG `URL` parser (`new URL(base + path)`), percent-encoded dot segments are resolved as path traversals and backslashes are normalized to forward slashes.
- **🎯 Impact:** Callers could issue requests with paths such as `/%2e%2e/admin` or `/servers\\..\\admin` to escape base URL path prefixes (e.g. `/v1`).
- **🔧 Fix:** Updated `normalizePath()` in `src/security.ts` to decode paths via `decodeURIComponent()` and validate against `"\\"` and `".."` in both raw and decoded strings, as well as rejecting malformed percent encodings.
- **✅ Verification:** Added unit tests in `test/smoke.ts` asserting that `%2e%2e`, `\`, `%5c`, and malformed percent encodings are rejected. Recorded critical security learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [10313172296070351921](https://jules.google.com/task/10313172296070351921) started by @mjmirza*