### PR TITLE
🛡️ Sentinel: Fix encoded and backslash path traversal in path normalization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,10 @@
+## 2026-08-23 - URL Path Normalization Traversal in WHATWG URL
+
+**Vulnerability:**
+`normalizePath` previously checked for `..` in the raw string, but missed percent-encoded representations (such as `%2e%2e` or `%2E%2E`) and backslashes (`\`). When appended to base API URLs using `new URL(base + path)`, Node's WHATWG `URL` parser automatically decodes `%2e%2e` and normalizes backslashes to slashes, resolving path segments and bypassing the `/v1` base API scope (SSRF / path traversal).
+
+**Learning:**
+String matching against `..` on raw path input is insufficient when the string will be processed by a URL parser or server that decodes percent-encoding or normalizes path separators.
+
+**Prevention:**
+Always decode input paths via `decodeURIComponent` (handling URIErrors) and explicitly check both raw and decoded inputs for `..` and `\` before passing them to `new URL()` or downstream request methods.

--- a/src/security.ts
+++ b/src/security.ts
@@ -19,8 +19,14 @@ export function normalizePath(path: string): string {
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw) || raw.startsWith("//")) {
     throw new Error("path must be a relative API path like /servers, not a full URL");
   }
-  if (raw.includes("..")) {
-    throw new Error("path must not contain '..'");
+  let decoded = raw;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    throw new Error("path contains invalid percent-encoding");
+  }
+  if (raw.includes("..") || raw.includes("\\") || decoded.includes("..") || decoded.includes("\\")) {
+    throw new Error("path must not contain '..' or '\\'");
   }
   for (let i = 0; i < raw.length; i++) {
     const c = raw.charCodeAt(i);

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -43,7 +43,6 @@ async function main(): Promise<void> {
   } catch {
     /* expected */
   }
-  assert("security: reject full URL path", secOk);
   let travOk = true;
   try {
     normalizePath("/servers/../../admin");
@@ -51,7 +50,26 @@ async function main(): Promise<void> {
   } catch {
     /* expected */
   }
-  assert("security: reject path traversal", travOk);
+  let encTravOk = true;
+  try {
+    normalizePath("/servers/%2e%2e/admin");
+    encTravOk = false;
+  } catch {
+    /* expected */
+  }
+  let backslashTravOk = true;
+  try {
+    normalizePath("..\\admin");
+    backslashTravOk = false;
+  } catch {
+    /* expected */
+  }
+  const secChecks = [
+    assert("security: reject full URL path", secOk),
+    assert("security: reject path traversal", travOk),
+    assert("security: reject encoded path traversal", encTravOk),
+    assert("security: reject backslash path traversal", backslashTravOk),
+  ];
 
   // Cost guard unit checks (no network). Billed creates and billed actions must be flagged,
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
@@ -73,8 +91,8 @@ async function main(): Promise<void> {
     await check("robot /server", "robot", "/server"),
   ];
   const passed =
-    results.filter(Boolean).length + (secOk ? 1 : 0) + (travOk ? 1 : 0) + costChecks.filter(Boolean).length;
-  const total = results.length + 2 + costChecks.length;
+    results.filter(Boolean).length + secChecks.filter(Boolean).length + costChecks.filter(Boolean).length;
+  const total = results.length + secChecks.length + costChecks.length;
   process.stdout.write(`\n${passed}/${total} checks passed\n`);
   if (passed !== total) process.exitCode = 1;
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Raw path checks in normalizePath allowed percent-encoded dot-dot sequences (%2e%2e) and backslashes (\) to pass through. When appended to base URLs, Node's WHATWG URL parser automatically normalizes these path segments, escaping the /v1 base API scope.
🎯 Impact: Path traversal / SSRF scope escape.
🔧 Fix: Decoded paths using decodeURIComponent and checked both raw and decoded strings for .. and \, as well as catching invalid percent-encoding.
✅ Verification: Added unit test assertions in test/smoke.ts and confirmed typecheck, smoke tests, and build pass.

---
*PR created automatically by Jules for task [9191141151127936662](https://jules.google.com/task/9191141151127936662) started by @mjmirza*