### PR TITLE
🛡️ Sentinel: Fix path traversal and SSRF via percent-encoding in normalizePath

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-07 - WHATWG URL Path Normalization & Percent Encoding Bypass
+**Vulnerability:** Input paths containing percent-encoded dot segments (`%2e%2e`) or backslashes (`\`) bypassed simple `string.includes("..")` checks in `normalizePath`. When passed to Node's WHATWG `URL` constructor, these sequences were resolved as path traversals.
+**Learning:** Node's WHATWG `URL` parser automatically resolves percent-encoded dots (`%2e%2e`) to `..` and normalizes backslashes (`\`) to `/` during URL resolution.
+**Prevention:** Always decode paths using `decodeURIComponent` before checking for path traversal (`..`), backslashes (`\`), or URL schemes, and safely handle invalid percent-encoding exceptions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hetzner-mcp",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hetzner-mcp",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/security.ts
+++ b/src/security.ts
@@ -19,15 +19,30 @@ export function normalizePath(path: string): string {
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw) || raw.startsWith("//")) {
     throw new Error("path must be a relative API path like /servers, not a full URL");
   }
-  if (raw.includes("..")) {
-    throw new Error("path must not contain '..'");
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    throw new Error("path contains invalid percent encoding");
   }
-  for (let i = 0; i < raw.length; i++) {
-    const c = raw.charCodeAt(i);
+
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(decoded) || decoded.startsWith("//")) {
+    throw new Error("path must be a relative API path like /servers, not a full URL");
+  }
+
+  // Reject path traversal and backslashes in raw and decoded paths to prevent SSRF and path escapes.
+  if (decoded.includes("..") || decoded.includes("\\") || raw.includes("..") || raw.includes("\\")) {
+    throw new Error("path must not contain '..' or '\\'");
+  }
+
+  for (let i = 0; i < decoded.length; i++) {
+    const c = decoded.charCodeAt(i);
     if (c < 0x20 || c === 0x7f) {
       throw new Error("path must not contain control characters");
     }
   }
+
   return raw.startsWith("/") ? raw : "/" + raw;
 }
 

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -53,6 +53,33 @@ async function main(): Promise<void> {
   }
   assert("security: reject path traversal", travOk);
 
+  let encodedTravOk = true;
+  try {
+    normalizePath("/servers/%2e%2e/admin");
+    encodedTravOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject encoded traversal", encodedTravOk);
+
+  let bsOk = true;
+  try {
+    normalizePath("/servers/..\\admin");
+    bsOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject backslash traversal", bsOk);
+
+  let malformedOk = true;
+  try {
+    normalizePath("/servers/%ff");
+    malformedOk = false;
+  } catch {
+    /* expected */
+  }
+  assert("security: reject invalid percent encoding", malformedOk);
+
   // Cost guard unit checks (no network). Billed creates and billed actions must be flagged,
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
   const costChecks = [
@@ -72,9 +99,10 @@ async function main(): Promise<void> {
     await check("storagebox /storage_box_types", "storagebox", "/storage_box_types"),
     await check("robot /server", "robot", "/server"),
   ];
+  const secChecks = [secOk, travOk, encodedTravOk, bsOk, malformedOk];
   const passed =
-    results.filter(Boolean).length + (secOk ? 1 : 0) + (travOk ? 1 : 0) + costChecks.filter(Boolean).length;
-  const total = results.length + 2 + costChecks.length;
+    results.filter(Boolean).length + secChecks.filter(Boolean).length + costChecks.filter(Boolean).length;
+  const total = results.length + secChecks.length + costChecks.length;
   process.stdout.write(`\n${passed}/${total} checks passed\n`);
   if (passed !== total) process.exitCode = 1;
 }


### PR DESCRIPTION
This PR hardens path normalization in `src/security.ts` by decoding input paths with `decodeURIComponent` before validation. This prevents bypasses using percent-encoded dot segments (`%2e%2e`), backslashes (`\`), or malformed percent encoding when constructing WHATWG `URL` objects. Tests in `test/smoke.ts` and Sentinel learning journal in `.jules/sentinel.md` have been updated.

---
*PR created automatically by Jules for task [3699893366621150794](https://jules.google.com/task/3699893366621150794) started by @mjmirza*