### PR TITLE
chore: gitignore the local .claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ coverage/
 
 # npm pack artifacts
 *.tgz
+
+# local Claude Code project-scoped config, never published
+.claude/


### PR DESCRIPTION
Adds .claude/ to .gitignore so a local Claude Code project-scoped config directory can never be committed by accident.