### PR TITLE
chore(release): 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 All notable changes to hetzner-mcp are documented here. The format is based on Keep a
 Changelog, and this project follows semantic versioning.
 
-## [Unreleased]
+## [0.3.1] - 2026-08-30
 
 ### Security
-- normalizePath now decodes a path once and rejects `..` and backslash in the
-  decoded form, so a percent-encoded traversal like `%2e%2e` cannot slip past the
-  literal checks. Defense in depth. the surface base URL fixes the host, so this
-  hardens caller intent rather than closing a live exploit.
+- normalizePath now unescapes a path once and rejects `..` and backslash in the
+  unescaped form, so a percent-encoded traversal like `%2e%2e` cannot slip past
+  the literal checks. Defense in depth. the surface base URL fixes the host, so
+  this hardens caller intent rather than closing a live exploit.
 - Patched transitive dependency advisories via npm audit fix. npm audit is back
   to 0 vulnerabilities in both the production and full trees. No production
   dependency changed (the tree is only the MCP SDK and zod).
@@ -20,6 +20,11 @@ Changelog, and this project follows semantic versioning.
   delta since the 2026-06-07 sweep (Data Center endpoint sunset after Oct 1,
   reverse-DNS dns_ptr and RRSet TTL now required, unassign-before-delete for
   assigned IPs). All are caller-side or additive, no curated tool is affected.
+
+### Fixed
+- README license badge and two prose spots corrected from a stale MIT plus
+  CC BY 4.0 description to the OpenRoots ORA 2.3 license the repository
+  actually carries in LICENSE.
 
 ## [0.3.0] - 2026-06-08
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hetzner-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hetzner-mcp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hetzner-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Model Context Protocol server for the full Hetzner platform. Cloud (servers, networks, volumes, firewalls, load balancers, IPs, DNS), Storage Box, and Robot dedicated servers. Spin up and manage every part of Hetzner from any MCP client.",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
Bumps the version, publishes the CHANGELOG Unreleased section as 0.3.1 dated today, and adds the README license fix to the release notes. The published npm package and the GitHub release were both still at 0.3.0, which predates the traversal-hardening and dependency-advisory patch merged in #54. This closes that gap.