### PR TITLE
docs(readme): remove standalone openroots badge under the logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 <img src="https://raw.githubusercontent.com/mjmirza/hetzner-mcp/master/assets/hetzner-cloud-logo.png" alt="Hetzner" height="56" />
 
-[![OpenRoots ORA 2.3](https://openroots.org/badge/ora.svg)](https://openroots.org/licenses/ora/2.3)
-
 Manage your entire Hetzner platform from any AI assistant. Cloud servers, networks, volumes, firewalls, load balancers, IPs and DNS, plus Storage Boxes and Robot dedicated servers. One Model Context Protocol server, every surface, tested live, with a hard cost guard so you never get a surprise bill.
 
 [![npm version](https://img.shields.io/npm/v/hetzner-mcp?logo=npm)](https://www.npmjs.com/package/hetzner-mcp)


### PR DESCRIPTION
Removes the standalone OpenRoots ORA 2.3 badge that sat directly under the logo. The License badge in the badge row below already states the same license, so this only drops the duplicate.