### PR TITLE
feat(setup): friendlier, Mastra-quality onboarding for setup and doctor

### DIFF
--- a/src/setup/doctor.ts
+++ b/src/setup/doctor.ts
@@ -8,6 +8,7 @@ import fs from "node:fs";
 import { loadConfig, availableSurfaces } from "../config.js";
 import { clientTargets, hasHetznerServer, tilde } from "./clients.js";
 import { validateCloudToken } from "./validate.js";
+import { bold, dim, green, red, cyan } from "./style.js";
 
 function out(s: string): void {
   stdout.write(s + "\n");
@@ -24,31 +25,32 @@ function flagToken(argv: string[]): string | undefined {
 export async function runDoctor(argv: string[]): Promise<number> {
   const cfg = loadConfig();
   out("");
-  out("  hetzner-mcp doctor");
+  out("  " + bold(cyan("hetzner-mcp doctor")));
+  out("  " + dim("A read-only health check. It looks, and changes nothing."));
   out("");
 
   // Token health. Prefer an explicit flag, else the environment.
   const token = flagToken(argv)?.trim() || cfg.cloudToken;
   if (token) {
-    out("  Verifying token against the Hetzner Cloud API...");
+    out(dim("  Checking your token with Hetzner..."));
     const check = await validateCloudToken(token);
-    out(`  ${check.ok ? "OK " : "x  "}Token: ${check.message}`);
+    out(`  ${check.ok ? green("OK ") : red("x  ")}${bold("Token")}. ${check.message}`);
   } else {
-    out("  -  Token: not set in this terminal. That is expected.");
-    out("     The token lives inside each MCP client config, not in your shell.");
-    out("     To check a token here, run: npx hetzner-mcp doctor --token <token>");
+    out(`  ${dim("-")}  ${bold("Token")}. Not set in this terminal, which is normal.`);
+    out(dim("     It lives inside each app's config, not in your shell."));
+    out(dim("     To check one here, run. npx hetzner-mcp doctor --token <token>"));
   }
 
   // Surfaces available from the current environment.
   const surfaces = availableSurfaces(cfg);
   out("");
-  out(`  Surfaces (from this environment): ${surfaces.length ? surfaces.join(", ") : "none"}`);
-  out(`  Write mode: ${cfg.readOnly ? "read-only (HETZNER_MCP_READONLY=1)" : "read and write"}`);
-  out(`  Billed creates: ${cfg.allowBilled ? "allowed with confirm" : "blocked (HETZNER_MCP_ALLOW_BILLED=0)"}`);
+  out(`  ${dim("Surfaces in this shell.")} ${surfaces.length ? surfaces.join(", ") : "none"}`);
+  out(`  ${dim("Write mode.")} ${cfg.readOnly ? "read-only (HETZNER_MCP_READONLY=1)" : "read and write"}`);
+  out(`  ${dim("Billed creates.")} ${cfg.allowBilled ? "allowed with confirm" : "blocked (HETZNER_MCP_ALLOW_BILLED=0)"}`);
 
   // Which known clients have hetzner wired.
   out("");
-  out("  MCP clients:");
+  out("  " + bold("Your apps:"));
   let wiredCount = 0;
   for (const t of clientTargets()) {
     let wired = false;
@@ -61,14 +63,19 @@ export async function runDoctor(argv: string[]): Promise<number> {
       }
     }
     if (wired) wiredCount++;
-    out(`    ${wired ? "OK " : "-  "}${t.name.padEnd(24)} ${wired ? tilde(t.configPath) : "not wired"}`);
+    const marker = wired ? green("OK ") : dim("-  ");
+    const tail = wired ? dim(tilde(t.configPath)) : dim("not connected yet");
+    out(`    ${marker}${t.name.padEnd(24)} ${tail}`);
   }
 
   out("");
   if (!wiredCount) {
-    out("  No clients are wired yet. Run:  npx hetzner-mcp setup");
+    out("  " + bold("No app is connected yet.") + " Set one up in one command.");
+    out("       " + cyan("npx hetzner-mcp setup"));
   } else {
-    out(`  ${wiredCount} client(s) wired. Ask your assistant to list your Hetzner servers.`);
+    out("  " + green(bold(`All good. ${wiredCount} app${wiredCount === 1 ? "" : "s"} connected.`)));
+    out("  Open a chat and ask, in plain words.");
+    out("       " + cyan('"List my Hetzner servers and show this month cost."'));
   }
   out("");
   return 0;

--- a/src/setup/style.ts
+++ b/src/setup/style.ts
@@ -1,0 +1,16 @@
+// Dependency-free terminal color for the wizard and doctor. Goes plain when output
+// is piped, or NO_COLOR / a dumb TERM is set, so CI and redirected output stay clean.
+import { stdout } from "node:process";
+
+const ESC = String.fromCharCode(27);
+const ON = Boolean(stdout.isTTY) && !process.env.NO_COLOR && process.env.TERM !== "dumb";
+
+function wrap(code: string): (s: string) => string {
+  return (s: string) => (ON ? `${ESC}[${code}m${s}${ESC}[0m` : s);
+}
+
+export const bold = wrap("1");
+export const dim = wrap("2");
+export const green = wrap("32");
+export const red = wrap("31");
+export const cyan = wrap("36");

--- a/src/setup/wizard.ts
+++ b/src/setup/wizard.ts
@@ -250,9 +250,11 @@ export async function runSetup(argv: string[]): Promise<number> {
 
     if (!chosen.length) {
       out("");
-      out("  No clients selected. Nothing was changed.");
-      out("  Re-run with --client claude-desktop (or claude-code, cursor, windsurf, vscode),");
-      out("  or use --print to copy the config block manually.");
+      out("  No app was selected, so nothing on your computer was changed.");
+      out("  Run setup again and pick at least one, for example:");
+      out("       npx hetzner-mcp setup --client claude-desktop");
+      out("  (other ids. claude-code, cursor, windsurf, vscode)");
+      out("  Or copy the config yourself with:  npx hetzner-mcp setup --print");
       return 0;
     }
 
@@ -269,18 +271,28 @@ export async function runSetup(argv: string[]): Promise<number> {
 
     if (!written.length) return 1;
 
-    // 5. Next steps.
+    // 5. Next steps. Warm, numbered, plain language so a first-timer knows exactly
+    // what to do. The technical backup note is demoted to a reassuring footer.
+    const robotNote = creds.HETZNER_ROBOT_USER ? " Your Robot credentials were saved too." : "";
+    const appWord = written.length === 1 ? "app" : "apps";
     out("");
-    out("  Done. Token wired as " + mask(token) + (creds.HETZNER_ROBOT_USER ? " with Robot credentials." : "."));
-    out("  Backups of any existing config were saved alongside with a .bak suffix.");
+    out("  Success. Your Hetzner account is now connected." + robotNote);
     out("");
-    out("  Next:");
-    for (const w of written) out(`    - ${w.target.name}: ${w.target.restartHint}`);
+    out("  Two small steps and you are ready:");
     out("");
-    out("  Then ask your assistant:");
-    out('    "List my Hetzner servers and show this month cost."');
+    out(`  1. Restart the ${appWord} below so the new connection loads.`);
+    for (const w of written) out(`       ${w.target.name}. ${w.target.restartHint}`);
     out("");
-    out("  Verify anytime with:  npx hetzner-mcp doctor");
+    out("  2. Open a chat and ask, in plain words:");
+    out('       "List my Hetzner servers and show this month cost."');
+    out("       No commands to learn. The answer comes straight from your account.");
+    out("");
+    out("  Not sure it worked? Run this any time and it will tell you in plain English:");
+    out("       npx hetzner-mcp doctor");
+    out("");
+    out("  Good to know, your token " + mask(token) + " was saved only inside the");
+    out(`  ${appWord === "app" ? "app's" : "apps'"} own config on this computer, never anywhere else, and any file that was`);
+    out("  already there was copied to a .bak backup first, so nothing was lost.");
     out("");
     return 0;
   } catch (err) {

--- a/src/setup/wizard.ts
+++ b/src/setup/wizard.ts
@@ -18,6 +18,7 @@ import {
   type ServerEntryEnv,
 } from "./clients.js";
 import { validateCloudToken } from "./validate.js";
+import { bold, dim, green, red, cyan } from "./style.js";
 
 interface Flags {
   token?: string;
@@ -132,8 +133,8 @@ export async function runSetup(argv: string[]): Promise<number> {
   }
 
   out("");
-  out("  hetzner-mcp setup");
-  out("  Connect any MCP client to your Hetzner account in under a minute.");
+  out("  " + bold(cyan("hetzner-mcp setup")));
+  out("  " + dim("Connect any MCP client to your Hetzner account in under a minute."));
   out("");
 
   const interactive = stdin.isTTY && !flags.yes;
@@ -177,9 +178,9 @@ export async function runSetup(argv: string[]): Promise<number> {
           verified = true;
           break;
         }
-        out("  Verifying...");
+        out(dim("  Verifying with Hetzner..."));
         const check = await validateCloudToken(token); // BESTPRACTICE_OK: verify must follow the prompt in this retry loop
-        out(`  ${check.ok ? "OK" : "x "} ${check.message}`);
+        out(`  ${check.ok ? green("OK") : red("x ")} ${check.message}`);
         if (check.ok) {
           verified = true;
           break;
@@ -200,7 +201,7 @@ export async function runSetup(argv: string[]): Promise<number> {
       }
     } else if (token && !flags.noVerify) {
       const check = await validateCloudToken(token);
-      out(`  ${check.ok ? "OK" : "x "} ${check.message}`);
+      out(`  ${check.ok ? green("OK") : red("x ")} ${check.message}`);
       if (!check.ok) {
         stderr.write("  Setup stopped. The provided token did not verify (use --no-verify to skip).\n");
         return 1;
@@ -263,7 +264,7 @@ export async function runSetup(argv: string[]): Promise<number> {
     for (const t of chosen) {
       try {
         written.push(writeClientConfig(t, creds));
-        out(`  OK wrote ${t.name} (${tilde(t.configPath)})`);
+        out(`  ${green("OK")} wrote ${bold(t.name)} ${dim(`(${tilde(t.configPath)})`)}`);
       } catch (err) {
         stderr.write(`  x  ${t.name}: ${err instanceof Error ? err.message : String(err)}\n`);
       }
@@ -276,23 +277,23 @@ export async function runSetup(argv: string[]): Promise<number> {
     const robotNote = creds.HETZNER_ROBOT_USER ? " Your Robot credentials were saved too." : "";
     const appWord = written.length === 1 ? "app" : "apps";
     out("");
-    out("  Success. Your Hetzner account is now connected." + robotNote);
+    out("  " + green(bold("Success. Your Hetzner account is now connected.")) + robotNote);
     out("");
-    out("  Two small steps and you are ready:");
+    out("  " + bold("Two small steps and you are ready:"));
     out("");
-    out(`  1. Restart the ${appWord} below so the new connection loads.`);
-    for (const w of written) out(`       ${w.target.name}. ${w.target.restartHint}`);
+    out(`  ${bold("1.")} Restart the ${appWord} below so the new connection loads.`);
+    for (const w of written) out(`       ${bold(w.target.name + ".")} ${w.target.restartHint}`);
     out("");
-    out("  2. Open a chat and ask, in plain words:");
-    out('       "List my Hetzner servers and show this month cost."');
-    out("       No commands to learn. The answer comes straight from your account.");
+    out(`  ${bold("2.")} Open a chat and ask, in plain words:`);
+    out('       ' + cyan('"List my Hetzner servers and show this month cost."'));
+    out("       " + dim("No commands to learn. The answer comes straight from your account."));
     out("");
-    out("  Not sure it worked? Run this any time and it will tell you in plain English:");
-    out("       npx hetzner-mcp doctor");
+    out("  " + dim("Not sure it worked? Run this any time and it will tell you in plain English:"));
+    out("       " + cyan("npx hetzner-mcp doctor"));
     out("");
-    out("  Good to know, your token " + mask(token) + " was saved only inside the");
-    out(`  ${appWord === "app" ? "app's" : "apps'"} own config on this computer, never anywhere else, and any file that was`);
-    out("  already there was copied to a .bak backup first, so nothing was lost.");
+    out(dim("  Good to know, your token " + mask(token) + " was saved only inside the"));
+    out(dim(`  ${appWord === "app" ? "app's" : "apps'"} own config on this computer, never anywhere else, and any file that was`));
+    out(dim("  already there was copied to a .bak backup first, so nothing was lost."));
     out("");
     return 0;
   } catch (err) {


### PR DESCRIPTION
## What

Brings the `setup` and `doctor` onboarding up to the polish of a modern CLI wizard, in response to feedback that the ending was confusing for a first-time, non-technical user. Two parts, no logic change.

### 1. Plain-language ending
Rewrites the final screen the wizard shows. The jargon word wired is gone, the numbered steps are explicit (restart the app, then ask in plain words), the doctor check is framed as the thing to run when unsure, and the technical backup note is demoted to a reassuring footer instead of leading. Pluralizes app vs apps correctly. The no-app-selected message is softened the same way.

### 2. Mastra-quality terminal polish
Adds dependency-free terminal color (`src/setup/style.ts`), applied to both `setup` and `doctor`. Bold cyan headers, green and red status markers, dim secondary text, and cyan for the commands to copy. Doctor's ending now states plainly whether your apps are connected and exactly what to do next.

Crucially it works, it is not just decoration. Color renders in a real terminal and goes fully plain the moment output is piped, or when NO_COLOR or a dumb TERM is set, so logs and CI stay clean. Verified with 0 escape bytes in piped output.

## Verification
- Ran the wizard end to end for one-app and multi-app cases, and doctor, in a real terminal (color) and piped (plain, 0 escape bytes).
- tsc clean, fallow 0 findings, offline setup suite 39/39, build green.

## Note on the two push overrides
The push guards flagged NO_COLOR/TERM as undeclared env vars (they are standard infra conventions, not app config) and test/setup.ts as an unused file (a pre-existing knip config quirk, run via tsx). Both are false positives for this change, overridden with an audit trail.
