### PR TITLE
chore(release): 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to hetzner-mcp are documented here. The format is based on Keep a
 Changelog, and this project follows semantic versioning.
 
+## [0.3.2] - 2026-08-30
+
+### Changed
+- Friendlier onboarding. The `setup` and `doctor` commands now speak plain
+  language for a first-time user, with numbered next steps, a clear success
+  screen, and the technical backup note demoted to a reassuring footer.
+- Added dependency-free terminal color to `setup` and `doctor`. It renders in a
+  real terminal and goes fully plain when output is piped or NO_COLOR is set, so
+  logs and CI stay clean. No new runtime dependency.
+
 ## [0.3.1] - 2026-08-30
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hetzner-mcp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hetzner-mcp",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hetzner-mcp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Model Context Protocol server for the full Hetzner platform. Cloud (servers, networks, volumes, firewalls, load balancers, IPs, DNS), Storage Box, and Robot dedicated servers. Spin up and manage every part of Hetzner from any MCP client.",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
Ships the friendlier, colorized setup and doctor onboarding to npm. version 0.3.2, CHANGELOG updated. No code change beyond the version bump and changelog.