### PR TITLE
docs: SSH/service layer as demand-gated, opt-in (Phase 7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,10 @@ This MCP is designed to grow from real use. If you ask it for something it does 
 - Open a [feature request or missing endpoint issue](https://github.com/mjmirza/hetzner-mcp/issues/new/choose).
 - Read [CONTRIBUTING.md](CONTRIBUTING.md) for the pull request flow.
 - Contributors are credited in [docs/CREDITS.md](docs/CREDITS.md).
+- Not included yet, on purpose. an on-server service layer (restart services, tail logs,
+  database health) is a planned, opt-in, allow-listed feature, kept out of the default so
+  the server stays safe by default. See docs/ROADMAP.md Phase 7, and open an issue if you
+  want it prioritized.
 
 ## Quality
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -59,6 +59,16 @@ Nothing ships as done until it actually works and is documented.
   community comparison (what other Hetzner MCPs expose vs this one).
 - CHANGELOG.md. Test gauntlet. Publish to npm and register in MCP directories.
 
+### Phase 7. On-server service layer (demand-gated, opt-in, NOT started)
+- Not built, and never built speculatively. The gate is real user demand, not a guess.
+- If demand appears, ship it the safe way only. a curated, allow-listed, read-mostly set
+  of service tools (service status, tail logs, config test, database health) behind an
+  explicit opt-in flag, never an arbitrary shell-exec tool by default. This preserves the
+  safe-by-default guarantee that separates this server from the ungated community ones.
+- Requires server login credentials, a larger blast radius than the API token, so it stays
+  off unless the operator turns it on.
+- Open an issue if you want it. that is how this phase gets prioritized.
+
 ## Credentials needed from you (only when its phase starts)
 
 | Phase | Needs | Where to find it |


### PR DESCRIPTION
Records the one gap vs the SSH-layer competitor as a planned, opt-in, allow-listed Phase 7 feature instead of building it speculatively. README contribution-loop note + ROADMAP Phase 7. Docs only, no code, no version bump.