### PR TITLE
Sentinel: Normalize path in cost guard to prevent bypass via query string

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2026-06-08 - Path Normalization in Cost Guard
+
+**Vulnerability:** Cost guard regex checks in `classifyCost` could be bypassed by appending query parameters (e.g. `POST /servers?foo=bar`) or omitting leading slashes (`POST servers`), causing billed operations to be misclassified as unbilled.
+
+**Learning:** Regexes matching full path string endpoints (like `/^\/servers\/?$/i`) will fail to match if query parameters or hash fragments are present in the path string passed to `classifyCost`.
+
+**Prevention:** Always normalize and strip query parameters and hash fragments from paths before performing exact or regex pattern matching for security or cost guards.

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -37,10 +37,13 @@ export interface CostDecision {
 export function classifyCost(surface: SurfaceName, method: string, path: string): CostDecision {
   const m = method.toUpperCase();
   if (m !== "POST" && m !== "PUT") return { billed: false };
+  const cleanPath = (path.split(/[?#]/)[0] || "").trim();
+  const normalizedPath = cleanPath.startsWith("/") ? cleanPath : "/" + cleanPath;
+
   for (const re of BILLED_CREATE[surface] ?? []) {
-    if (re.test(path)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
+    if (re.test(normalizedPath)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
   }
-  if (surface === "cloud" && BILLED_ACTIONS.test(path)) {
+  if (surface === "cloud" && BILLED_ACTIONS.test(normalizedPath)) {
     return { billed: true, reason: `${m} ${path} is an action that can increase your bill` };
   }
   return { billed: false };

--- a/src/tools/generic.ts
+++ b/src/tools/generic.ts
@@ -108,7 +108,9 @@ function registerOne(server: McpServer, cfg: HetznerConfig, surface: SurfaceName
             }
             if (args.confirm !== true) {
               let note = "";
-              if (surface === "cloud" && /^\/servers\/?$/i.test(args.path)) {
+              const cleanPath = (args.path.split(/[?#]/)[0] || "").trim();
+              const normPath = cleanPath.startsWith("/") ? cleanPath : "/" + cleanPath;
+              if (surface === "cloud" && /^\/servers\/?$/i.test(normPath)) {
                 const body = bodyVal as { server_type?: string } | undefined;
                 const priced = await cloudServerPriceNote(cfg, body?.server_type);
                 if (priced) note = " " + priced;

--- a/test/eval.ts
+++ b/test/eval.ts
@@ -92,6 +92,8 @@ function unitChecks(): Row[] {
   const cost = (name: string, got: boolean, want: boolean) =>
     rows.push({ group: "cost-guard", name, detail: `billed=${got}`, status: got === want ? "PASS" : "FAIL" });
   cost("POST /servers is billed", classifyCost("cloud", "POST", "/servers").billed, true);
+  cost("POST /servers?foo=bar is billed", classifyCost("cloud", "POST", "/servers?foo=bar").billed, true);
+  cost("POST servers is billed", classifyCost("cloud", "POST", "servers").billed, true);
   cost("POST /ssh_keys is free", classifyCost("cloud", "POST", "/ssh_keys").billed, false);
   cost("DELETE /servers/1 is not billed", classifyCost("cloud", "DELETE", "/servers/1").billed, false);
   cost("POST /storage_boxes is billed", classifyCost("storagebox", "POST", "/storage_boxes").billed, true);

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -78,6 +78,9 @@ async function main(): Promise<void> {
     assert("cost: create_image is billed", classifyCost("cloud", "POST", "/servers/9/actions/create_image").billed),
     assert("cost: change_type is billed", classifyCost("cloud", "POST", "/servers/9/actions/change_type").billed),
     assert("cost: volume resize is billed", classifyCost("cloud", "POST", "/volumes/9/actions/resize").billed),
+    assert("cost: server create with query param is billed", classifyCost("cloud", "POST", "/servers?foo=bar").billed),
+    assert("cost: server create without leading slash is billed", classifyCost("cloud", "POST", "servers").billed),
+    assert("cost: action with query param is billed", classifyCost("cloud", "POST", "/servers/9/actions/change_type?foo=bar").billed),
     assert("cost: poweron is free", !classifyCost("cloud", "POST", "/servers/9/actions/poweron").billed),
     assert("cost: list is free", !classifyCost("cloud", "GET", "/servers").billed),
   ];


### PR DESCRIPTION
## Summary

The cost guard regex matching in `classifyCost` (`src/cost.ts`) and `generic_request` (`src/tools/generic.ts`) checked the raw path string without stripping query parameters or hash fragments. As a result, requests like `POST /servers?param=value` or `POST servers` could bypass cost classification regexes and avoid requiring cost confirmation for billed operations.

## Risk

An attacker or misconfigured client could execute billed creation/action endpoints with query parameters appended, bypassing the cost guard prompt and incurring unintended charges.

## Fix

The path is now normalized in `classifyCost` and `src/tools/generic.ts` by stripping query parameters (`?...`) and hash fragments (`#...`) and ensuring a leading slash before performing regex pattern matching against `BILLED_CREATE` and `BILLED_ACTIONS`.

## Verification

- Added regression tests in `test/smoke.ts` and `test/eval.ts` covering path normalization with query strings and non-leading-slash paths in cost classification.
- Ran `npm run typecheck`, `npm run build`, and `npm run test:offline` (all 39 setup/clients tests and 52 api-shape tests passed).
- Ran `npx tsx test/smoke.ts` (13/13 offline security and cost checks passed).

## Scope

No authentication, authorization, or public API contract was changed.

## Duplication Check

Checked existing PRs and commits; no duplicate open or merged fixes exist for this path normalization issue in cost classification.

---
*PR created automatically by Jules for task [6280544301095446309](https://jules.google.com/task/6280544301095446309) started by @mjmirza*