### PR TITLE
Sentinel: [HIGH] Normalize path in cost classification guard

### DIFF
--- a/src/cost.ts
+++ b/src/cost.ts
@@ -37,10 +37,17 @@ export interface CostDecision {
 export function classifyCost(surface: SurfaceName, method: string, path: string): CostDecision {
   const m = method.toUpperCase();
   if (m !== "POST" && m !== "PUT") return { billed: false };
-  for (const re of BILLED_CREATE[surface] ?? []) {
-    if (re.test(path)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
+
+  // Strip query parameters and hash fragments, and normalize leading slash before matching against billing regexes.
+  let cleanPath = (path || "").split("?")[0].split("#")[0];
+  if (!cleanPath.startsWith("/")) {
+    cleanPath = "/" + cleanPath;
   }
-  if (surface === "cloud" && BILLED_ACTIONS.test(path)) {
+
+  for (const re of BILLED_CREATE[surface] ?? []) {
+    if (re.test(cleanPath)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
+  }
+  if (surface === "cloud" && BILLED_ACTIONS.test(cleanPath)) {
     return { billed: true, reason: `${m} ${path} is an action that can increase your bill` };
   }
   return { billed: false };

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -75,7 +75,9 @@ async function main(): Promise<void> {
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
   const costChecks = [
     assert("cost: server create is billed", classifyCost("cloud", "POST", "/servers").billed),
+    assert("cost: server create with query is billed", classifyCost("cloud", "POST", "/servers?location=fsn1").billed),
     assert("cost: create_image is billed", classifyCost("cloud", "POST", "/servers/9/actions/create_image").billed),
+    assert("cost: create_image with hash is billed", classifyCost("cloud", "POST", "/servers/9/actions/create_image#hash").billed),
     assert("cost: change_type is billed", classifyCost("cloud", "POST", "/servers/9/actions/change_type").billed),
     assert("cost: volume resize is billed", classifyCost("cloud", "POST", "/volumes/9/actions/resize").billed),
     assert("cost: poweron is free", !classifyCost("cloud", "POST", "/servers/9/actions/poweron").billed),


### PR DESCRIPTION
## Severity

HIGH

## Summary

The cost classification guard in `src/cost.ts` matched request paths directly against regexes expected to begin or end with specific collection paths (e.g. `^\/servers\/?$`). When request paths included query parameters (e.g. `/servers?location=fsn1`) or hash fragments (e.g. `/servers/1/actions/create_image#hash`), regex matching failed, allowing billed operations to bypass confirmation requirements.

## Impact

An attacker or misconfigured client could execute billed operations (such as creating servers or snapshot images) without triggering cost confirmation guards by appending query parameters or hash fragments to the path.

## Fix

The `classifyCost` function in `src/cost.ts` now normalizes the input path by stripping query parameters (`?...`) and hash fragments (`#...`) and ensuring a leading slash before matching against billing regex patterns.

## Verification

- Added regression unit tests in `test/smoke.ts` covering paths with query parameters and hash fragments.
- Verified that typecheck (`npm run typecheck`), build (`npm run build`), offline unit tests (`npm run test:offline`), and smoke test suite (`npm run smoke`) pass.

## Scope

The change is strictly limited to path normalization in `src/cost.ts` and test coverage additions in `test/smoke.ts`. No authentication, authorization, or API signatures were altered.

## Duplication Check

Checked existing PRs and codebase history; no active or past fix covers path normalization in `classifyCost`.

---
*PR created automatically by Jules for task [5833547077505636461](https://jules.google.com/task/5833547077505636461) started by @mjmirza*