### PR TITLE
Sentinel: Prevent cost guard bypass via unnormalized API paths

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2026-03-31 - Cost Guard Path Normalization
+
+**Vulnerability:** Unnormalized API paths containing query parameters, hash fragments, or missing leading slashes bypassed cost classification in `classifyCost`, allowing billed resource creation requests without confirmation.
+
+**Learning:** Route matching regexes anchored with `^` and `$` fail when input paths contain unexpected query strings or URL fragments, even though the underlying HTTP client will still route the request to the endpoint.
+
+**Prevention:** Always normalize input paths (stripping query parameters and hash fragments, and ensuring a leading slash) before performing security route matching or cost classification.

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -37,10 +37,16 @@ export interface CostDecision {
 export function classifyCost(surface: SurfaceName, method: string, path: string): CostDecision {
   const m = method.toUpperCase();
   if (m !== "POST" && m !== "PUT") return { billed: false };
+
+  // Normalize path to strip query params/hash fragments and ensure leading slash
+  // before matching against billing route regexes.
+  const cleanPath = (path ? path.split("?")[0].split("#")[0] : "").trim();
+  const normalizedPath = cleanPath.startsWith("/") ? cleanPath : "/" + cleanPath;
+
   for (const re of BILLED_CREATE[surface] ?? []) {
-    if (re.test(path)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
+    if (re.test(normalizedPath)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
   }
-  if (surface === "cloud" && BILLED_ACTIONS.test(path)) {
+  if (surface === "cloud" && BILLED_ACTIONS.test(normalizedPath)) {
     return { billed: true, reason: `${m} ${path} is an action that can increase your bill` };
   }
   return { billed: false };

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -80,6 +80,9 @@ async function main(): Promise<void> {
     assert("cost: volume resize is billed", classifyCost("cloud", "POST", "/volumes/9/actions/resize").billed),
     assert("cost: poweron is free", !classifyCost("cloud", "POST", "/servers/9/actions/poweron").billed),
     assert("cost: list is free", !classifyCost("cloud", "GET", "/servers").billed),
+    assert("cost: query param path is billed", classifyCost("cloud", "POST", "/servers?foo=bar").billed),
+    assert("cost: hash fragment path is billed", classifyCost("cloud", "POST", "/servers#hash").billed),
+    assert("cost: missing leading slash is billed", classifyCost("cloud", "POST", "servers").billed),
   ];
 
   // Live free reads across all three surfaces.


### PR DESCRIPTION
## Summary

This fix normalizes API paths evaluated by the cost guard (`classifyCost` in `src/cost.ts`) before matching them against billing route regexes.

## Risk

Unnormalized input paths containing query parameters (for example `/servers?foo=bar`), hash fragments (for example `/servers#hash`), or missing leading slashes (for example `servers`) bypassed anchored billing route regexes (`/^\/servers\/?$/i`). This could allow billed resource creation requests without requiring confirmation or enforcing billing safety controls.

## Fix

`classifyCost` now strips query strings and hash fragments and ensures a leading slash on the path prior to regex evaluation.

## Verification

- Added regression test assertions in `test/smoke.ts` covering paths with query parameters, hash fragments, and missing leading slashes.
- Verified all type checking (`npm run typecheck`), offline unit tests (`npm run test:offline`), smoke checks (`npm run smoke`), and build (`npm run build`).

## Scope

No authentication, authorization, API contracts, or unrelated application behavior was changed.

## Duplication Check

Checked relevant codebase state and journal entries; no existing active PR or fix was present for this vulnerability.

---
*PR created automatically by Jules for task [18139613249695215218](https://jules.google.com/task/18139613249695215218) started by @mjmirza*