### PR TITLE
Sentinel: Harden cost guard path classification against query string bypass

### DIFF
--- a/src/cost.ts
+++ b/src/cost.ts
@@ -37,10 +37,12 @@ export interface CostDecision {
 export function classifyCost(surface: SurfaceName, method: string, path: string): CostDecision {
   const m = method.toUpperCase();
   if (m !== "POST" && m !== "PUT") return { billed: false };
+  const cleanPath = (path.split(/[?#]/)[0] || "").trim();
+  const normalizedPath = cleanPath.startsWith("/") ? cleanPath : "/" + cleanPath;
   for (const re of BILLED_CREATE[surface] ?? []) {
-    if (re.test(path)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
+    if (re.test(normalizedPath)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
   }
-  if (surface === "cloud" && BILLED_ACTIONS.test(path)) {
+  if (surface === "cloud" && BILLED_ACTIONS.test(normalizedPath)) {
     return { billed: true, reason: `${m} ${path} is an action that can increase your bill` };
   }
   return { billed: false };

--- a/test/eval.ts
+++ b/test/eval.ts
@@ -92,6 +92,8 @@ function unitChecks(): Row[] {
   const cost = (name: string, got: boolean, want: boolean) =>
     rows.push({ group: "cost-guard", name, detail: `billed=${got}`, status: got === want ? "PASS" : "FAIL" });
   cost("POST /servers is billed", classifyCost("cloud", "POST", "/servers").billed, true);
+  cost("POST /servers?foo=bar is billed", classifyCost("cloud", "POST", "/servers?foo=bar").billed, true);
+  cost("POST servers is billed", classifyCost("cloud", "POST", "servers").billed, true);
   cost("POST /ssh_keys is free", classifyCost("cloud", "POST", "/ssh_keys").billed, false);
   cost("DELETE /servers/1 is not billed", classifyCost("cloud", "DELETE", "/servers/1").billed, false);
   cost("POST /storage_boxes is billed", classifyCost("storagebox", "POST", "/storage_boxes").billed, true);

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -75,6 +75,8 @@ async function main(): Promise<void> {
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
   const costChecks = [
     assert("cost: server create is billed", classifyCost("cloud", "POST", "/servers").billed),
+    assert("cost: server create with query is billed", classifyCost("cloud", "POST", "/servers?foo=bar").billed),
+    assert("cost: server create without leading slash is billed", classifyCost("cloud", "POST", "servers").billed),
     assert("cost: create_image is billed", classifyCost("cloud", "POST", "/servers/9/actions/create_image").billed),
     assert("cost: change_type is billed", classifyCost("cloud", "POST", "/servers/9/actions/change_type").billed),
     assert("cost: volume resize is billed", classifyCost("cloud", "POST", "/volumes/9/actions/resize").billed),


### PR DESCRIPTION
## Summary

This change normalizes input paths in `classifyCost` prior to matching against billing regexes (`BILLED_CREATE` and `BILLED_ACTIONS`). Query strings (`?...`) and hash fragments (`#...`) are stripped, and a leading slash is ensured.

## Risk

When query strings or un-prefixed relative paths were supplied to `classifyCost`, regex anchors (like `/^\/servers\/?$/i`) could fail to match, potentially bypassing the cost guard prompt requirement for billed operations.

## Fix

`classifyCost` now cleans and normalizes the path before executing regex tests.

## Verification

- Added cost guard unit test cases covering query parameters and missing leading slashes in `test/smoke.ts` and `test/eval.ts`.
- Executed `npm run typecheck` and `npm run test:offline`. All checks passed.

## Scope

Tightly scoped to `src/cost.ts` and unit test assertions in `test/smoke.ts` and `test/eval.ts`.

## Duplication Check

Verified existing pull requests, issues, and commits. No duplicate active or merged pull request was found.

---
*PR created automatically by Jules for task [15088973896486642640](https://jules.google.com/task/15088973896486642640) started by @mjmirza*