### PR TITLE
Sentinel: [HIGH] Prevent cost guard bypass via path query parameters and fragments

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2026-08-30 - Cost Guard Path Normalization
+
+**Vulnerability:** Paths passed to cost guard (`classifyCost`) with query parameters (`/servers?foo=bar`), hash fragments (`/servers#hash`), or missing leading slashes (`servers`) failed exact regex matching against `BILLED_CREATE` and `BILLED_ACTIONS`, returning `billed: false` and bypassing cost checks.
+
+**Learning:** Input paths must be stripped of query parameters and hash fragments and normalized with a leading slash before matching against cost classification patterns.
+
+**Prevention:** Always normalize and strip query/hash components from paths when evaluating security or authorization guards prior to routing or request execution.

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -37,10 +37,18 @@ export interface CostDecision {
 export function classifyCost(surface: SurfaceName, method: string, path: string): CostDecision {
   const m = method.toUpperCase();
   if (m !== "POST" && m !== "PUT") return { billed: false };
-  for (const re of BILLED_CREATE[surface] ?? []) {
-    if (re.test(path)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
+
+  // Strip query parameters and hash fragments, and ensure a leading slash
+  // so query/hash strings or relative path formats do not bypass billing checks.
+  let normalized = path.trim().split("?")[0].split("#")[0];
+  if (!normalized.startsWith("/")) {
+    normalized = "/" + normalized;
   }
-  if (surface === "cloud" && BILLED_ACTIONS.test(path)) {
+
+  for (const re of BILLED_CREATE[surface] ?? []) {
+    if (re.test(normalized)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
+  }
+  if (surface === "cloud" && BILLED_ACTIONS.test(normalized)) {
     return { billed: true, reason: `${m} ${path} is an action that can increase your bill` };
   }
   return { billed: false };

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -75,7 +75,11 @@ async function main(): Promise<void> {
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
   const costChecks = [
     assert("cost: server create is billed", classifyCost("cloud", "POST", "/servers").billed),
+    assert("cost: server create with query is billed", classifyCost("cloud", "POST", "/servers?foo=bar").billed),
+    assert("cost: server create without leading slash is billed", classifyCost("cloud", "POST", "servers").billed),
+    assert("cost: server create with fragment is billed", classifyCost("cloud", "POST", "/servers#hash").billed),
     assert("cost: create_image is billed", classifyCost("cloud", "POST", "/servers/9/actions/create_image").billed),
+    assert("cost: create_image with query is billed", classifyCost("cloud", "POST", "/servers/9/actions/create_image?foo=bar").billed),
     assert("cost: change_type is billed", classifyCost("cloud", "POST", "/servers/9/actions/change_type").billed),
     assert("cost: volume resize is billed", classifyCost("cloud", "POST", "/volumes/9/actions/resize").billed),
     assert("cost: poweron is free", !classifyCost("cloud", "POST", "/servers/9/actions/poweron").billed),


### PR DESCRIPTION
## Severity

HIGH

## Summary

The cost classification function `classifyCost` matched incoming request paths against end-anchored regular expressions to determine whether an operation creates a billed resource or performs a cost-incurring action. Paths containing query parameters, hash fragments, or missing leading slashes failed to match these regular expressions and were classified as non-billed, bypassing cost guard confirmation checks.

## Impact

An attacker or caller passing query parameters or hash fragments (e.g. `POST /servers?foo=bar`) could bypass the cost guard and trigger cost-incurring resource creation without explicit confirmation.

## Fix

The `classifyCost` function now normalizes the path by stripping query parameters (`?...`), stripping hash fragments (`#...`), and ensuring a leading slash before evaluating the billing regular expressions.

## Verification

- Added regression assertions in `test/smoke.ts` covering path variations with query parameters, hash fragments, and relative path formats.
- Verified that all unit tests, type checks, and offline tests pass cleanly (`npm run typecheck`, `npm run test:offline`).

## Scope

The change affects only path normalization within cost classification in `src/cost.ts` and associated unit checks in `test/smoke.ts`.

## Duplication Check

Checked existing issues, commits, and pull requests and confirmed no equivalent active or merged fix exists for cost guard path normalization.

---
*PR created automatically by Jules for task [14629618297013539750](https://jules.google.com/task/14629618297013539750) started by @mjmirza*