### PR TITLE
Sentinel: Fix cost guard path normalization bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2025-05-18 - Cost Guard Path Normalization
+
+**Vulnerability:** Input paths with query string parameters (`/servers?foo=bar`), URL fragments, or missing leading slashes bypassed `classifyCost` regex checks, allowing unconfirmed creation of billed Hetzner resources.
+
+**Learning:** `classifyCost` matched against raw input paths without stripping query strings or hash fragments or ensuring a leading slash, causing regex boundaries (`$`) to fail on paths like `/servers?option=true`.
+
+**Prevention:** Always normalize input paths to strip query strings (`?...`), hash fragments (`#...`), and ensure a leading slash before matching against cost classification regexes.

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -37,11 +37,15 @@ export interface CostDecision {
 export function classifyCost(surface: SurfaceName, method: string, path: string): CostDecision {
   const m = method.toUpperCase();
   if (m !== "POST" && m !== "PUT") return { billed: false };
-  for (const re of BILLED_CREATE[surface] ?? []) {
-    if (re.test(path)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
+  let normalized = (path || "").trim().split("?")[0].split("#")[0];
+  if (!normalized.startsWith("/")) {
+    normalized = "/" + normalized;
   }
-  if (surface === "cloud" && BILLED_ACTIONS.test(path)) {
-    return { billed: true, reason: `${m} ${path} is an action that can increase your bill` };
+  for (const re of BILLED_CREATE[surface] ?? []) {
+    if (re.test(normalized)) return { billed: true, reason: `${m} ${normalized} creates a billed ${surface} resource` };
+  }
+  if (surface === "cloud" && BILLED_ACTIONS.test(normalized)) {
+    return { billed: true, reason: `${m} ${normalized} is an action that can increase your bill` };
   }
   return { billed: false };
 }

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -11,6 +11,7 @@ import {
 } from "../src/setup/clients.js";
 import { parseSetupFlags } from "../src/setup/wizard.js";
 import { validateCloudToken } from "../src/setup/validate.js";
+import { classifyCost } from "../src/cost.js";
 
 let passed = 0;
 let total = 0;
@@ -117,6 +118,12 @@ async function main(): Promise<void> {
   assert("timeout not ok and explained", timedOut.ok === false && timedOut.message.includes("timed out"));
   const netErr = await validateCloudToken("tok", stubFetchThrow("TypeError"));
   assert("network error not ok", netErr.ok === false && netErr.message.includes("Could not reach"));
+
+  // Cost guard path normalization tests.
+  assert("cost guard handles query parameters", classifyCost("cloud", "POST", "/servers?foo=bar").billed);
+  assert("cost guard handles hash fragments", classifyCost("cloud", "POST", "/servers#section").billed);
+  assert("cost guard handles missing leading slash", classifyCost("cloud", "POST", "servers").billed);
+  assert("cost guard handles action with query params", classifyCost("cloud", "POST", "/servers/1/actions/create_image?param=1").billed);
 
   process.stdout.write(`\n${passed}/${total} checks passed\n`);
   if (passed !== total) process.exitCode = 1;

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -75,7 +75,10 @@ async function main(): Promise<void> {
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
   const costChecks = [
     assert("cost: server create is billed", classifyCost("cloud", "POST", "/servers").billed),
+    assert("cost: server create with query is billed", classifyCost("cloud", "POST", "/servers?foo=bar").billed),
+    assert("cost: server create without leading slash is billed", classifyCost("cloud", "POST", "servers").billed),
     assert("cost: create_image is billed", classifyCost("cloud", "POST", "/servers/9/actions/create_image").billed),
+    assert("cost: create_image with query is billed", classifyCost("cloud", "POST", "/servers/9/actions/create_image?x=1").billed),
     assert("cost: change_type is billed", classifyCost("cloud", "POST", "/servers/9/actions/change_type").billed),
     assert("cost: volume resize is billed", classifyCost("cloud", "POST", "/volumes/9/actions/resize").billed),
     assert("cost: poweron is free", !classifyCost("cloud", "POST", "/servers/9/actions/poweron").billed),


### PR DESCRIPTION
## Summary

The cost-classification logic in `classifyCost` previously matched raw input paths against end-anchored billing regexes (`/^\/servers\/?$/i`).

## Risk

Unsanitized paths containing query strings (e.g. `/servers?foo=bar`), URL fragments, or missing leading slashes failed regex matching, bypassing cost-guard confirmation checks when creating billed resources or modifying billing state.

## Fix

`classifyCost` now normalizes input paths by stripping query parameters (`?...`), hash fragments (`#...`), and ensuring a leading slash before matching against billing patterns.

## Verification

- Added offline regression tests in `test/setup.ts` and `test/smoke.ts`.
- Ran `npm run typecheck` and `npm run test:offline` (43 setup tests and 52 api-shape tests passed).
- Built project via `npm run build`.

## Scope

Changes are strictly confined to `src/cost.ts` and associated test files.

## Duplication Check

Checked existing PRs and codebase history; no active or merged duplicate PR addresses this cost guard normalization bypass.

---
*PR created automatically by Jules for task [6122467306220500622](https://jules.google.com/task/6122467306220500622) started by @mjmirza*