### PR TITLE
Sentinel: Fix cost guard path normalization bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2026-06-07 - Cost Guard Path Normalization Bypass
+
+**Vulnerability:** Raw input paths containing query strings, hash fragments, or lacking leading slashes bypassed regex pattern matching in `classifyCost`, allowing write operations to create billed resources without confirmation.
+
+**Learning:** URL pattern matching for cost classification must be decoupled from query parameters and fragments, as HTTP request dispatchers reconcile raw paths into normalized endpoint URLs.
+
+**Prevention:** Always normalize and clean API paths by stripping query strings, fragments, and whitespace, and ensuring leading slashes before performing cost classification or access control checks.

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -34,13 +34,23 @@ export interface CostDecision {
   reason?: string;
 }
 
+function normalizeCostPath(path: string): string {
+  if (!path) return "/";
+  let clean = path.split("?")[0].split("#")[0].trim();
+  if (!clean.startsWith("/")) {
+    clean = "/" + clean;
+  }
+  return clean;
+}
+
 export function classifyCost(surface: SurfaceName, method: string, path: string): CostDecision {
   const m = method.toUpperCase();
   if (m !== "POST" && m !== "PUT") return { billed: false };
+  const normalizedPath = normalizeCostPath(path);
   for (const re of BILLED_CREATE[surface] ?? []) {
-    if (re.test(path)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
+    if (re.test(normalizedPath)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
   }
-  if (surface === "cloud" && BILLED_ACTIONS.test(path)) {
+  if (surface === "cloud" && BILLED_ACTIONS.test(normalizedPath)) {
     return { billed: true, reason: `${m} ${path} is an action that can increase your bill` };
   }
   return { billed: false };

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -75,6 +75,8 @@ async function main(): Promise<void> {
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
   const costChecks = [
     assert("cost: server create is billed", classifyCost("cloud", "POST", "/servers").billed),
+    assert("cost: server create with query is billed", classifyCost("cloud", "POST", "/servers?foo=bar").billed),
+    assert("cost: server create without leading slash is billed", classifyCost("cloud", "POST", "servers").billed),
     assert("cost: create_image is billed", classifyCost("cloud", "POST", "/servers/9/actions/create_image").billed),
     assert("cost: change_type is billed", classifyCost("cloud", "POST", "/servers/9/actions/change_type").billed),
     assert("cost: volume resize is billed", classifyCost("cloud", "POST", "/volumes/9/actions/resize").billed),


### PR DESCRIPTION
## Summary
Raw input paths containing query strings, hash fragments, or lacking leading slashes bypassed regex pattern matching in classifyCost, allowing write operations to create billed resources without required confirmation.

## Fix
Normalized input paths in classifyCost by stripping query parameters and hash fragments and ensuring a leading slash before matching against billing regexes.

## Verification
- Added cost guard unit tests in test/smoke.ts.
- Verified build, typecheck, offline tests, and smoke tests pass.

---
*PR created automatically by Jules for task [14736964996167651428](https://jules.google.com/task/14736964996167651428) started by @mjmirza*