### PR TITLE
Sentinel: Fix cost guard path bypass via URL query parameters and fragments

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2026-06-07 - Cost Classification Path Normalization
+
+**Vulnerability:** Input paths with query strings or hash fragments bypassed the cost guard because regex matching expected anchored resource paths.
+
+**Learning:** When regexes use start and end anchors to match API collection paths, raw request parameters or URL fragments prevent matching unless stripped beforehand.
+
+**Prevention:** Always normalize request paths by stripping query parameters and hash fragments and ensuring a leading slash before matching against billing regexes.

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -37,10 +37,17 @@ export interface CostDecision {
 export function classifyCost(surface: SurfaceName, method: string, path: string): CostDecision {
   const m = method.toUpperCase();
   if (m !== "POST" && m !== "PUT") return { billed: false };
-  for (const re of BILLED_CREATE[surface] ?? []) {
-    if (re.test(path)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
+
+  // Strip query string and hash fragments, then ensure leading slash to prevent cost-guard bypasses.
+  let normalizedPath = path.split(/[?#]/)[0].trim();
+  if (!normalizedPath.startsWith("/")) {
+    normalizedPath = "/" + normalizedPath;
   }
-  if (surface === "cloud" && BILLED_ACTIONS.test(path)) {
+
+  for (const re of BILLED_CREATE[surface] ?? []) {
+    if (re.test(normalizedPath)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
+  }
+  if (surface === "cloud" && BILLED_ACTIONS.test(normalizedPath)) {
     return { billed: true, reason: `${m} ${path} is an action that can increase your bill` };
   }
   return { billed: false };

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -75,6 +75,9 @@ async function main(): Promise<void> {
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
   const costChecks = [
     assert("cost: server create is billed", classifyCost("cloud", "POST", "/servers").billed),
+    assert("cost: query string server create is billed", classifyCost("cloud", "POST", "/servers?foo=bar").billed),
+    assert("cost: hash fragment server create is billed", classifyCost("cloud", "POST", "/servers#hash").billed),
+    assert("cost: unslashed server create is billed", classifyCost("cloud", "POST", "servers").billed),
     assert("cost: create_image is billed", classifyCost("cloud", "POST", "/servers/9/actions/create_image").billed),
     assert("cost: change_type is billed", classifyCost("cloud", "POST", "/servers/9/actions/change_type").billed),
     assert("cost: volume resize is billed", classifyCost("cloud", "POST", "/volumes/9/actions/resize").billed),


### PR DESCRIPTION
## Severity

HIGH

## Summary

Input paths containing query parameters or hash fragments bypassed the cost guard checks when matching against anchored billing regexes.

## Impact

An attacker or client constructing requests with query parameters (for example `POST /servers?foo=bar`) could bypass the cost guard, causing cost-incurring operations to execute without confirmation.

## Fix

`classifyCost` in `src/cost.ts` now normalizes the input path by stripping query strings and hash fragments and ensuring a leading slash before matching against billing regex patterns.

## Verification

- Added unit tests in `test/smoke.ts` covering paths with query parameters, hash fragments, and missing leading slashes.
- Verified all type checking (`npm run typecheck`), offline tests (`npm run test:offline`), smoke checks (`npm run smoke`), and build (`npm run build`).

## Scope

The change affects cost classification path normalization only and preserves all existing API contracts.

## Duplication Check

Checked open and closed issues and pull requests; no equivalent active or previous fix exists.

---
*PR created automatically by Jules for task [1721937480059093375](https://jules.google.com/task/1721937480059093375) started by @mjmirza*