### PR TITLE
Sentinel: [HIGH] Prevent cost guard bypass via unnormalized path

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2026-06-07 - Normalize Paths in Cost Classification
+
+**Vulnerability:** Unnormalized paths containing query strings (`/servers?foo=bar`), hash fragments (`/servers#hash`), or missing leading slashes (`servers`) failed to match strict billing regexes in `classifyCost`, bypassing the cost guard during write requests.
+
+**Learning:** When matching API endpoint paths against billing or authorization regexes, input paths must be normalized to strip query parameters (`?...`) and hash fragments (`#...`) and ensure a leading slash before evaluation.
+
+**Prevention:** Always strip query parameters and hash fragments and normalize path prefixes before performing regex classification on request paths.

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -37,10 +37,15 @@ export interface CostDecision {
 export function classifyCost(surface: SurfaceName, method: string, path: string): CostDecision {
   const m = method.toUpperCase();
   if (m !== "POST" && m !== "PUT") return { billed: false };
-  for (const re of BILLED_CREATE[surface] ?? []) {
-    if (re.test(path)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
+  let cleanPath = (path ?? "").split(/[?#]/)[0] ?? "";
+  cleanPath = cleanPath.trim();
+  if (cleanPath && !cleanPath.startsWith("/")) {
+    cleanPath = "/" + cleanPath;
   }
-  if (surface === "cloud" && BILLED_ACTIONS.test(path)) {
+  for (const re of BILLED_CREATE[surface] ?? []) {
+    if (re.test(cleanPath)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
+  }
+  if (surface === "cloud" && BILLED_ACTIONS.test(cleanPath)) {
     return { billed: true, reason: `${m} ${path} is an action that can increase your bill` };
   }
   return { billed: false };

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -75,7 +75,11 @@ async function main(): Promise<void> {
   // free actions and reads must not be. create_image is the snapshot action from issue #2.
   const costChecks = [
     assert("cost: server create is billed", classifyCost("cloud", "POST", "/servers").billed),
+    assert("cost: query string bypass is billed", classifyCost("cloud", "POST", "/servers?foo=bar").billed),
+    assert("cost: hash fragment bypass is billed", classifyCost("cloud", "POST", "/servers#hash").billed),
+    assert("cost: missing leading slash is billed", classifyCost("cloud", "POST", "servers").billed),
     assert("cost: create_image is billed", classifyCost("cloud", "POST", "/servers/9/actions/create_image").billed),
+    assert("cost: create_image with query is billed", classifyCost("cloud", "POST", "/servers/9/actions/create_image?opt=1").billed),
     assert("cost: change_type is billed", classifyCost("cloud", "POST", "/servers/9/actions/change_type").billed),
     assert("cost: volume resize is billed", classifyCost("cloud", "POST", "/volumes/9/actions/resize").billed),
     assert("cost: poweron is free", !classifyCost("cloud", "POST", "/servers/9/actions/poweron").billed),


### PR DESCRIPTION
## Severity

HIGH

## Summary

The cost classification function `classifyCost` used unnormalized path strings when checking against regex patterns for billed resource creation and actions.

## Impact

An attacker or automated client passing query parameters (`/servers?foo=bar`), hash fragments (`/servers#hash`), or paths without a leading slash (`servers`) could cause `classifyCost` to return `{ billed: false }`, bypassing the cost guard and creating billed Hetzner resources without requiring user confirmation (`confirm: true`).

## Fix

`classifyCost` in `src/cost.ts` now normalizes input paths by stripping query parameters (`?...`) and hash fragments (`#...`) and ensuring a leading slash (`/`) before testing against `BILLED_CREATE` and `BILLED_ACTIONS` regexes.

## Verification

- Added unit tests in `test/smoke.ts` covering paths with query strings, hash fragments, and missing leading slashes.
- Verified all offline tests and smoke unit tests pass (`npm run test:offline` and `npm run smoke`).
- Ran `npm run build` and `npm run typecheck`.

## Scope

The change is localized to `src/cost.ts` and `test/smoke.ts`. No external contracts or authentication/authorization logic were modified.

## Duplication Check

No existing open or merged pull requests cover path normalization in `classifyCost`.

---
*PR created automatically by Jules for task [3853812608956489972](https://jules.google.com/task/3853812608956489972) started by @mjmirza*