### PR TITLE
Sentinel: Prevent cost guard bypass via query params in cost classification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2026-09-08 - Path Normalization in Cost Guard
+
+**Vulnerability:** Paths with query strings, hash fragments, or missing leading slashes (e.g., `/servers?foo=bar`) bypassed the cost guard regex checks, allowing billed creation requests to proceed without requiring confirmation or enforcing billed creation restrictions.
+
+**Learning:** URL paths passed to cost classification functions can contain query parameters or fragments that fail exact regex matches anchored with `$`.
+
+**Prevention:** Always normalize URL paths by stripping `?` query strings and `#` hash fragments and ensuring a leading `/` before matching against cost-guard or security regexes.

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -37,10 +37,14 @@ export interface CostDecision {
 export function classifyCost(surface: SurfaceName, method: string, path: string): CostDecision {
   const m = method.toUpperCase();
   if (m !== "POST" && m !== "PUT") return { billed: false };
+
+  let cleanPath = (path || "").split("?")[0].split("#")[0];
+  if (!cleanPath.startsWith("/")) cleanPath = "/" + cleanPath;
+
   for (const re of BILLED_CREATE[surface] ?? []) {
-    if (re.test(path)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
+    if (re.test(cleanPath)) return { billed: true, reason: `${m} ${path} creates a billed ${surface} resource` };
   }
-  if (surface === "cloud" && BILLED_ACTIONS.test(path)) {
+  if (surface === "cloud" && BILLED_ACTIONS.test(cleanPath)) {
     return { billed: true, reason: `${m} ${path} is an action that can increase your bill` };
   }
   return { billed: false };

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -11,6 +11,7 @@ import {
 } from "../src/setup/clients.js";
 import { parseSetupFlags } from "../src/setup/wizard.js";
 import { validateCloudToken } from "../src/setup/validate.js";
+import { classifyCost } from "../src/cost.js";
 
 let passed = 0;
 let total = 0;
@@ -117,6 +118,12 @@ async function main(): Promise<void> {
   assert("timeout not ok and explained", timedOut.ok === false && timedOut.message.includes("timed out"));
   const netErr = await validateCloudToken("tok", stubFetchThrow("TypeError"));
   assert("network error not ok", netErr.ok === false && netErr.message.includes("Could not reach"));
+
+  // classifyCost normalization checks
+  assert("classifyCost handles query params", classifyCost("cloud", "POST", "/servers?foo=bar").billed === true);
+  assert("classifyCost handles hash fragments", classifyCost("cloud", "POST", "/servers#section").billed === true);
+  assert("classifyCost handles unslashed path", classifyCost("cloud", "POST", "servers").billed === true);
+  assert("classifyCost handles action with query params", classifyCost("cloud", "POST", "/servers/123/actions/change_type?async=true").billed === true);
 
   process.stdout.write(`\n${passed}/${total} checks passed\n`);
   if (passed !== total) process.exitCode = 1;


### PR DESCRIPTION
Normalizes the input path in classifyCost to strip query parameters, hash fragments, and ensure a leading slash before matching against cost-guard regexes, preventing cost guard bypasses.

---
*PR created automatically by Jules for task [367391712502338916](https://jules.google.com/task/367391712502338916) started by @mjmirza*